### PR TITLE
abort if the key config content type does not conform to spec

### DIFF
--- a/src/dap/client.spec.ts
+++ b/src/dap/client.spec.ts
@@ -151,9 +151,7 @@ describe("DAPClient", () => {
       assert.equal(fetch.calls.length, 0);
     });
 
-    // this is pending because of a bug in janus
-    //    it("throws an error if the content type is not correct", async () => {
-    it("accepts any content type", async () => {
+    it("throws an error if the content type is not correct", async () => {
       const params = buildParams();
       const taskId = params.taskId.buffer.toString("base64url");
       const fetch = mockFetch({
@@ -172,9 +170,7 @@ describe("DAPClient", () => {
       });
       const client = new DAPClient(params);
       client.fetch = fetch;
-
-      await assert.doesNotReject(client.fetchKeyConfiguration());
-
+      await assert.rejects(client.fetchKeyConfiguration());
       assert.equal(fetch.calls.length, 2);
     });
   });

--- a/src/dap/client.ts
+++ b/src/dap/client.ts
@@ -280,11 +280,8 @@ export class DAPClient<Measurement> {
         const blob = await response.blob();
 
         if (blob.type !== CONTENT_TYPES.HPKE_CONFIG) {
-          ///          throw new Error( <- this is the correct behavior, but janus sends a generic content-type currently
-          ///             `expected ${CONTENT_TYPES.HPKE_CONFIG} content-type header, aborting`
-          ///          );
-          console.error(
-            `expected ${CONTENT_TYPES.HPKE_CONFIG} content-type header, continuing for now`
+          throw new Error(
+            `expected ${CONTENT_TYPES.HPKE_CONFIG} content-type header, aborting`
           );
         }
 


### PR DESCRIPTION
this may break testing against current janus