### PR TITLE
remove Vector from all interfaces

### DIFF
--- a/src/common.spec.ts
+++ b/src/common.spec.ts
@@ -41,7 +41,7 @@ describe("common", () => {
     });
 
     it("round trips some large numbers", () => {
-      for (const n of Field128.fillRandom(100).toValues()) {
+      for (const n of Field128.fillRandom(100)) {
         assert.equal(
           n,
           octetStringToInteger(integerToOctetString(n, Field128.encodedSize))

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,10 +27,15 @@ export function octetStringToInteger(octetString: Uint8Array): bigint {
 }
 
 /** @internal */
-export function arr<T>(n: number, mapper: (n: number) => T): T[] {
-  const a = new Array(n) as T[];
-  for (let i = 0; i < n; i++) a[i] = mapper(i);
+export function arr<T>(length: number, mapper: (n: number) => T): T[] {
+  const a = new Array(length) as T[];
+  for (let i = 0; i < length; i++) a[i] = mapper(i);
   return a;
+}
+
+/** @internal */
+export function fill<T>(length: number, value: T): T[] {
+  return new Array(length).fill(value) as T[];
 }
 
 /** @internal */

--- a/src/dap/client.spec.ts
+++ b/src/dap/client.spec.ts
@@ -6,7 +6,7 @@ import { RequestInit, RequestInfo, Response, Request } from "undici";
 import * as hpke from "hpke";
 import { TaskId } from "dap/taskId";
 import { DAPError } from "./errors";
-import { arr, zip } from "common";
+import { fill, zip } from "common";
 
 interface Fetch {
   (input: RequestInfo, init?: RequestInit | undefined): Promise<Response>;
@@ -207,7 +207,7 @@ describe("DAPClient", () => {
       );
 
       const aad = Buffer.from([
-        ...arr(32, () => 1),
+        ...fill(32, 1),
         ...report.nonce.encode(),
         ...[0, 0],
       ]);

--- a/src/field.spec.ts
+++ b/src/field.spec.ts
@@ -36,6 +36,11 @@ function testField(field: Field, name: string) {
       assert.throws(() => field.decode(oneByteTooShort));
     });
 
+    it("throws when decoding an element that is not within the field", () => {
+      const value = field.encode([field.modulus + 1n]);
+      assert.throws(() => field.decode(value));
+    });
+
     it("encodes and decodes a round trip correctly", () => {
       const randVec = field.fillRandom(10);
       assert.deepEqual(randVec, field.decode(field.encode(randVec)));

--- a/src/field.spec.ts
+++ b/src/field.spec.ts
@@ -4,11 +4,6 @@ import { arr } from "common";
 
 function testField(field: Field, name: string) {
   describe(name, () => {
-    it("can allocate a zeroed vec of some length", () => {
-      const vec = arr(23, () => 0n);
-      assert.equal(23, vec.length);
-    });
-
     describe("modulus arithmetic within the field", () => {
       const x = field.randomElement();
       const y = field.randomElement();
@@ -34,10 +29,10 @@ function testField(field: Field, name: string) {
     });
 
     it("does not decode when the field is not a multiple of encodedSize", () => {
-      const oneByteTooLong = Buffer.from(arr(field.encodedSize + 1, () => 10));
+      const oneByteTooLong = Buffer.alloc(field.encodedSize + 1, 10);
       assert.throws(() => field.decode(oneByteTooLong));
 
-      const oneByteTooShort = Buffer.from(arr(field.encodedSize - 1, () => 10));
+      const oneByteTooShort = Buffer.alloc(field.encodedSize - 1, 10);
       assert.throws(() => field.decode(oneByteTooShort));
     });
 
@@ -52,7 +47,7 @@ function testField(field: Field, name: string) {
 
     it("correctly interpolates polynomials", () => {
       const p = field.fillRandom(10);
-      const xs = arr(10, (i) => BigInt(i));
+      const xs = arr(10, BigInt);
       const ys = xs.map((x) => field.evalPoly(p, x));
       const q = field.interpolate(xs, ys);
       for (const x of xs) {

--- a/src/field.spec.ts
+++ b/src/field.spec.ts
@@ -5,7 +5,7 @@ import { arr } from "common";
 function testField(field: Field, name: string) {
   describe(name, () => {
     it("can allocate a zeroed vec of some length", () => {
-      const vec = field.vec(23);
+      const vec = arr(23, () => 0n);
       assert.equal(23, vec.length);
     });
 
@@ -54,7 +54,7 @@ function testField(field: Field, name: string) {
       const p = field.fillRandom(10);
       const xs = arr(10, (i) => BigInt(i));
       const ys = xs.map((x) => field.evalPoly(p, x));
-      const q = field.interpolate(field.vec(xs), field.vec(ys));
+      const q = field.interpolate(xs, ys);
       for (const x of xs) {
         const a = field.evalPoly(p, x);
         const b = field.evalPoly(q, x);

--- a/src/field.ts
+++ b/src/field.ts
@@ -42,14 +42,6 @@ export class Field {
     return this.#finiteField.evalPolyAt(pVec, x);
   }
 
-  vec(data: number | bigint[]): bigint[] {
-    if (typeof data === "number") {
-      return arr(data, () => 0n);
-    } else {
-      return data.map((d) => this.mod(d));
-    }
-  }
-
   interpolate(xs: bigint[], ys: bigint[]): bigint[] {
     const xsVec = this.#finiteField.newVectorFrom(xs);
     const ysVec = this.#finiteField.newVectorFrom(ys);
@@ -103,17 +95,19 @@ export class Field {
       );
     }
 
-    return this.vec(
-      arr(encoded.length / encodedSize, (index) =>
-        octetStringToInteger(
-          encoded.slice(index * encodedSize, (index + 1) * encodedSize)
-        )
-      )
-    );
+    return arr(encoded.length / encodedSize, (index) => {
+      const n = octetStringToInteger(
+        encoded.slice(index * encodedSize, (index + 1) * encodedSize)
+      );
+      if (n >= this.modulus) {
+        throw new Error("decoded an element that is not in the field");
+      }
+      return n;
+    });
   }
 
   fillRandom(length: number): bigint[] {
-    return this.vec(arr(length, () => this.#finiteField.rand()));
+    return arr(length, () => this.#finiteField.rand());
   }
 
   sum<T>(arr: T[], mapper: (value: T, index: number) => bigint): bigint {

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,4 +1,4 @@
-import { FiniteField, createPrimeField, Vector } from "@guildofweavers/galois";
+import { FiniteField, createPrimeField } from "@guildofweavers/galois";
 export { Vector } from "@guildofweavers/galois";
 import { integerToOctetString, octetStringToInteger, arr } from "common";
 
@@ -37,20 +37,24 @@ export class Field {
     return this.#finiteField.exp(b, exp);
   }
 
-  evalPoly(p: Vector, x: bigint): bigint {
-    return this.#finiteField.evalPolyAt(p, x);
+  evalPoly(p: bigint[], x: bigint): bigint {
+    const pVec = this.#finiteField.newVectorFrom(p);
+    return this.#finiteField.evalPolyAt(pVec, x);
   }
 
-  vec(data: number | bigint[]): Vector {
+  vec(data: number | bigint[]): bigint[] {
     if (typeof data === "number") {
-      return this.#finiteField.newVectorFrom(arr(data, () => 0n));
+      return arr(data, () => 0n);
     } else {
-      return this.#finiteField.newVectorFrom(data.map((d) => this.mod(d)));
+      return data.map((d) => this.mod(d));
     }
   }
 
-  interpolate(xs: Vector, ys: Vector): Vector {
-    return this.#finiteField.interpolate(xs, ys);
+  interpolate(xs: bigint[], ys: bigint[]): bigint[] {
+    const xsVec = this.#finiteField.newVectorFrom(xs);
+    const ysVec = this.#finiteField.newVectorFrom(ys);
+
+    return this.#finiteField.interpolate(xsVec, ysVec).toValues();
   }
 
   add(a: bigint, b: bigint): bigint {
@@ -61,29 +65,37 @@ export class Field {
     return this.#finiteField.mul(a, b);
   }
 
-  mulPolys(a: Vector, b: Vector): Vector {
-    return this.#finiteField.mulPolys(a, b);
+  mulPolys(a: bigint[], b: bigint[]): bigint[] {
+    const aVec = this.#finiteField.newVectorFrom(a);
+    const bVec = this.#finiteField.newVectorFrom(b);
+
+    return this.#finiteField.mulPolys(aVec, bVec).toValues();
   }
 
   randomElement(): bigint {
     return this.#finiteField.rand();
   }
 
-  encode(data: Vector): Buffer {
+  encode(data: bigint[]): Buffer {
     return Buffer.concat(
-      data.toValues().map((x) => integerToOctetString(x, this.encodedSize))
+      data.map((x) => integerToOctetString(x, this.encodedSize))
     );
   }
 
-  vecSub(a: Vector, b: Vector): Vector {
-    return this.#finiteField.subVectorElements(a, b);
+  vecSub(a: bigint[], b: bigint[]): bigint[] {
+    const aVec = this.#finiteField.newVectorFrom(a);
+    const bVec = this.#finiteField.newVectorFrom(b);
+
+    return this.#finiteField.subVectorElements(aVec, bVec).toValues();
   }
 
-  vecAdd(a: Vector, b: Vector): Vector {
-    return this.#finiteField.addVectorElements(a, b);
+  vecAdd(a: bigint[], b: bigint[]): bigint[] {
+    const aVec = this.#finiteField.newVectorFrom(a);
+    const bVec = this.#finiteField.newVectorFrom(b);
+    return this.#finiteField.addVectorElements(aVec, bVec).toValues();
   }
 
-  decode(encoded: Buffer): Vector {
+  decode(encoded: Buffer): bigint[] {
     const encodedSize = this.encodedSize;
     if (encoded.length % encodedSize !== 0) {
       throw new Error(
@@ -100,7 +112,7 @@ export class Field {
     );
   }
 
-  fillRandom(length: number): Vector {
+  fillRandom(length: number): bigint[] {
     return this.vec(arr(length, () => this.#finiteField.rand()));
   }
 

--- a/src/field.ts
+++ b/src/field.ts
@@ -25,10 +25,6 @@ export class Field {
     );
   }
 
-  mod(i: bigint): bigint {
-    return i % this.modulus;
-  }
-
   sub(x: bigint, y: bigint): bigint {
     return this.#finiteField.sub(x, y);
   }

--- a/src/prio3/circuit.ts
+++ b/src/prio3/circuit.ts
@@ -1,4 +1,4 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { Gadget } from "prio3/gadget";
 import { nextPowerOf2 } from "common";
 
@@ -14,9 +14,9 @@ export interface GenericCircuit {
   gadgets: Gadget[];
   gadgetCalls: number[];
 
-  eval(input: Vector, jointRand: Vector, shares: number): bigint;
-  encode(measurement: unknown): Vector;
-  truncate(input: Vector): Vector;
+  eval(input: bigint[], jointRand: bigint[], shares: number): bigint;
+  encode(measurement: unknown): bigint[];
+  truncate(input: bigint[]): bigint[];
 }
 
 export abstract class Circuit<M> implements GenericCircuit {
@@ -27,9 +27,9 @@ export abstract class Circuit<M> implements GenericCircuit {
   abstract gadgets: Gadget[];
   abstract gadgetCalls: number[];
 
-  abstract eval(input: Vector, jointRand: Vector, shares: number): bigint;
-  abstract encode(measurement: M): Vector;
-  abstract truncate(input: Vector): Vector;
+  abstract eval(input: bigint[], jointRand: bigint[], shares: number): bigint;
+  abstract encode(measurement: M): bigint[];
+  abstract truncate(input: bigint[]): bigint[];
 
   get proveRandLen(): number {
     return this.gadgets.reduce((sum, gadget) => sum + gadget.arity, 0);
@@ -51,7 +51,7 @@ export abstract class Circuit<M> implements GenericCircuit {
     return this.gadgets.reduce((sum, gadget) => sum + gadget.arity + 1, 1);
   }
 
-  ensureValidEval(input: Vector, jointRand: Vector) {
+  ensureValidEval(input: bigint[], jointRand: bigint[]) {
     if (input.length != this.inputLen) {
       throw new Error(
         `expected input length to be ${this.inputLen} but it was ${input.length}`

--- a/src/prio3/circuits/count.ts
+++ b/src/prio3/circuits/count.ts
@@ -12,12 +12,10 @@ export class Count extends Circuit<boolean> {
 
   eval(input: bigint[], jointRand: bigint[], _shares: number): bigint {
     this.ensureValidEval(input, jointRand);
-    const inputZero = input[0];
+    const { field } = this;
+    const [inputZero] = input;
     const [mul] = this.gadgets;
-    return this.field.sub(
-      mul.eval(this.field, this.field.vec([inputZero, inputZero])),
-      inputZero
-    );
+    return field.sub(mul.eval(field, [inputZero, inputZero]), inputZero);
   }
 
   encode(measurement: boolean): bigint[] {
@@ -25,7 +23,7 @@ export class Count extends Circuit<boolean> {
       throw new Error("expected count measurement to be a boolean");
     }
 
-    return this.field.vec([measurement ? 1n : 0n]);
+    return [measurement ? 1n : 0n];
   }
 
   truncate(input: bigint[]): bigint[] {

--- a/src/prio3/circuits/count.ts
+++ b/src/prio3/circuits/count.ts
@@ -1,5 +1,5 @@
 import { Circuit } from "prio3/circuit";
-import { Field64, Vector } from "field";
+import { Field64 } from "field";
 import { Mul } from "prio3/gadgets/mul";
 
 export class Count extends Circuit<boolean> {
@@ -10,9 +10,9 @@ export class Count extends Circuit<boolean> {
   outputLen = 1;
   field = Field64;
 
-  eval(input: Vector, jointRand: Vector, _shares: number): bigint {
+  eval(input: bigint[], jointRand: bigint[], _shares: number): bigint {
     this.ensureValidEval(input, jointRand);
-    const inputZero = input.getValue(0);
+    const inputZero = input[0];
     const [mul] = this.gadgets;
     return this.field.sub(
       mul.eval(this.field, this.field.vec([inputZero, inputZero])),
@@ -20,7 +20,7 @@ export class Count extends Circuit<boolean> {
     );
   }
 
-  encode(measurement: boolean): Vector {
+  encode(measurement: boolean): bigint[] {
     if (typeof measurement !== "boolean") {
       throw new Error("expected count measurement to be a boolean");
     }
@@ -28,7 +28,7 @@ export class Count extends Circuit<boolean> {
     return this.field.vec([measurement ? 1n : 0n]);
   }
 
-  truncate(input: Vector): Vector {
+  truncate(input: bigint[]): bigint[] {
     if (input.length !== 1) {
       throw new Error("expected Count input to be exactly one boolean");
     }

--- a/src/prio3/circuits/histogram.ts
+++ b/src/prio3/circuits/histogram.ts
@@ -28,7 +28,7 @@ export class Histogram extends Circuit<number> {
     const f = this.field;
 
     const rangeCheck = f.sum(input, (value, index) =>
-      f.mul(f.exp(firstRand, BigInt(index)), gadget.eval(f, f.vec([value])))
+      f.mul(f.exp(firstRand, BigInt(index)), gadget.eval(f, [value]))
     );
 
     const sumCheck = f.sum(
@@ -46,7 +46,7 @@ export class Histogram extends Circuit<number> {
     const boundaries = [...this.buckets, Infinity];
     const encoded = boundaries.map(() => 0n);
     encoded[boundaries.findIndex((b) => measurement <= b)] = 1n;
-    return this.field.vec(encoded);
+    return encoded;
   }
 
   truncate(input: bigint[]): bigint[] {

--- a/src/prio3/circuits/proof.ts
+++ b/src/prio3/circuits/proof.ts
@@ -1,5 +1,5 @@
 import { Circuit } from "prio3/circuit";
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { Proof as ProofGadget } from "prio3/gadgets/proof";
 
 export class Proof<M> extends Circuit<M> {
@@ -26,19 +26,19 @@ export class Proof<M> extends Circuit<M> {
     return this.circuit.jointRandLen;
   }
 
-  eval(input: Vector, jointRand: Vector, shares: number): bigint {
+  eval(input: bigint[], jointRand: bigint[], shares: number): bigint {
     return this.circuit.eval.call(this, input, jointRand, shares);
   }
 
-  encode(measurement: M): Vector {
+  encode(measurement: M): bigint[] {
     return this.circuit.encode.call(this, measurement);
   }
 
-  truncate(input: Vector): Vector {
+  truncate(input: bigint[]): bigint[] {
     return this.circuit.truncate.call(this, input);
   }
 
-  constructor(circuit: Circuit<M>, proveRand: Vector) {
+  constructor(circuit: Circuit<M>, proveRand: bigint[]) {
     super();
 
     this.circuit = circuit;
@@ -46,22 +46,18 @@ export class Proof<M> extends Circuit<M> {
       throw new Error("prove rand was not the correct length");
     }
 
-    const proveRandValues = proveRand.toValues();
     let proveRandIndex = 0;
 
     this.gadgets = circuit.gadgets.map(
       (gadget, index) =>
         new ProofGadget(
-          proveRandValues.slice(
-            proveRandIndex,
-            (proveRandIndex += gadget.arity)
-          ),
+          proveRand.slice(proveRandIndex, (proveRandIndex += gadget.arity)),
           gadget,
           this.gadgetCalls[index]
         )
     );
 
-    if (proveRandValues.length !== proveRandIndex) {
+    if (proveRand.length !== proveRandIndex) {
       throw new Error("did not use all of the proof randomness");
     }
   }

--- a/src/prio3/circuits/query.ts
+++ b/src/prio3/circuits/query.ts
@@ -51,10 +51,7 @@ export class Query<M> extends Circuit<M> {
       const gadgetPolyLen = gadget.degree * (p - 1) + 1;
 
       const wireSeeds = proof.slice(proofIndex, (proofIndex += gadget.arity));
-
-      const gadgetPoly = circuit.field.vec(
-        proof.slice(proofIndex, (proofIndex += gadgetPolyLen))
-      );
+      const gadgetPoly = proof.slice(proofIndex, (proofIndex += gadgetPolyLen));
 
       return new QueryGadget(
         circuit.field,

--- a/src/prio3/circuits/sum.ts
+++ b/src/prio3/circuits/sum.ts
@@ -30,7 +30,7 @@ export class Sum extends Circuit<number> {
     return field.sum(input, (value, index) =>
       field.mul(
         field.exp(jointRandZero, BigInt(index)),
-        poly.eval(field, field.vec([value]))
+        poly.eval(field, [value])
       )
     );
   }
@@ -48,17 +48,15 @@ export class Sum extends Circuit<number> {
       );
     }
 
-    return this.field.vec(
-      arr(this.inputLen, (index) => BigInt((measurement >> index) & 1))
-    );
+    return arr(this.inputLen, (index) => BigInt((measurement >> index) & 1));
   }
 
   truncate(input: bigint[]): bigint[] {
     const field = this.field;
-    return field.vec([
+    return [
       field.sum(input, (value, index) =>
         field.mul(field.exp(2n, BigInt(index)), value)
       ),
-    ]);
+    ];
   }
 }

--- a/src/prio3/circuits/sum.ts
+++ b/src/prio3/circuits/sum.ts
@@ -1,5 +1,5 @@
 import { Circuit } from "prio3/circuit";
-import { Field128, Vector } from "field";
+import { Field128 } from "field";
 import { PolyEval } from "prio3/gadgets/polyEval";
 import { arr } from "common";
 
@@ -21,13 +21,13 @@ export class Sum extends Circuit<number> {
     this.inputLen = bits;
   }
 
-  eval(input: Vector, jointRand: Vector, _shares: number): bigint {
+  eval(input: bigint[], jointRand: bigint[], _shares: number): bigint {
     this.ensureValidEval(input, jointRand);
     const [poly] = this.gadgets;
     const field = this.field;
-    const jointRandZero = jointRand.getValue(0);
+    const jointRandZero = jointRand[0];
 
-    return field.sum(input.toValues(), (value, index) =>
+    return field.sum(input, (value, index) =>
       field.mul(
         field.exp(jointRandZero, BigInt(index)),
         poly.eval(field, field.vec([value]))
@@ -35,7 +35,7 @@ export class Sum extends Circuit<number> {
     );
   }
 
-  encode(measurement: number): Vector {
+  encode(measurement: number): bigint[] {
     if (
       measurement !== Math.floor(measurement) ||
       measurement < 0 ||
@@ -53,10 +53,10 @@ export class Sum extends Circuit<number> {
     );
   }
 
-  truncate(input: Vector): Vector {
+  truncate(input: bigint[]): bigint[] {
     const field = this.field;
     return field.vec([
-      field.sum(input.toValues(), (value, index) =>
+      field.sum(input, (value, index) =>
         field.mul(field.exp(2n, BigInt(index)), value)
       ),
     ]);

--- a/src/prio3/flp.spec.ts
+++ b/src/prio3/flp.spec.ts
@@ -39,7 +39,7 @@ class TestFlp implements Flp<number> {
 
   encode(measurement: number): bigint[] {
     if (this.inRange(measurement)) {
-      return this.field.vec([BigInt(measurement), BigInt(measurement)]);
+      return [BigInt(measurement), BigInt(measurement)];
     } else {
       throw new Error("encode");
     }
@@ -66,7 +66,7 @@ class TestFlp implements Flp<number> {
   }
 
   truncate(input: bigint[]): bigint[] {
-    return this.field.vec([input[0]]);
+    return [input[0]];
   }
 }
 
@@ -81,6 +81,6 @@ describe("flp", () => {
     const flp = new TestFlp128();
     assert(runFlp(flp, flp.encode(0), 1));
     assert(runFlp(flp, flp.encode(4), 1));
-    assert(!runFlp(flp, Field128.vec([BigInt(1337)]), 1));
+    assert(!runFlp(flp, [BigInt(1337)], 1));
   });
 });

--- a/src/prio3/flp.spec.ts
+++ b/src/prio3/flp.spec.ts
@@ -1,8 +1,12 @@
 import assert from "assert";
-import { Field, Field128, Vector } from "field";
+import { Field, Field128 } from "field";
 import { Flp } from "prio3/flp";
 
-export function runFlp<M>(flp: Flp<M>, input: Vector, shares: number): boolean {
+export function runFlp<M>(
+  flp: Flp<M>,
+  input: bigint[],
+  shares: number
+): boolean {
   const jointRand = flp.field.fillRandom(flp.jointRandLen);
   const proveRand = flp.field.fillRandom(flp.proveRandLen);
   const queryRand = flp.field.fillRandom(flp.queryRandLen);
@@ -33,7 +37,7 @@ class TestFlp implements Flp<number> {
     return n >= min && n < max;
   }
 
-  encode(measurement: number): Vector {
+  encode(measurement: number): bigint[] {
     if (this.inRange(measurement)) {
       return this.field.vec([BigInt(measurement), BigInt(measurement)]);
     } else {
@@ -41,28 +45,28 @@ class TestFlp implements Flp<number> {
     }
   }
 
-  prove(input: Vector, _queryRand: Vector, _jointRand: Vector): Vector {
+  prove(input: bigint[], _queryRand: bigint[], _jointRand: bigint[]): bigint[] {
     return input;
   }
 
-  decide(verifier: Vector): boolean {
+  decide(verifier: bigint[]): boolean {
     if (verifier.length !== 2) return false;
-    const value0 = verifier.getValue(0);
-    return value0 === verifier.getValue(1) && this.inRange(Number(value0));
+    const value0 = verifier[0];
+    return value0 === verifier[1] && this.inRange(Number(value0));
   }
 
   query(
-    input: Vector,
-    _proof: Vector,
-    _queryRand: Vector,
-    _jointRand: Vector,
+    input: bigint[],
+    _proof: bigint[],
+    _queryRand: bigint[],
+    _jointRand: bigint[],
     _shares: number
-  ): Vector {
+  ): bigint[] {
     return input;
   }
 
-  truncate(input: Vector): Vector {
-    return this.field.vec([input.getValue(0)]);
+  truncate(input: bigint[]): bigint[] {
+    return this.field.vec([input[0]]);
   }
 }
 

--- a/src/prio3/flp.ts
+++ b/src/prio3/flp.ts
@@ -1,4 +1,4 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 
 export interface Flp<M> {
   jointRandLen: number;
@@ -10,19 +10,19 @@ export interface Flp<M> {
   verifierLen: number;
   field: Field;
 
-  encode(measurement: M): Vector;
+  encode(measurement: M): bigint[];
 
-  prove(input: Vector, proveRand: Vector, jointRand: Vector): Vector;
+  prove(input: bigint[], proveRand: bigint[], jointRand: bigint[]): bigint[];
 
   query(
-    input: Vector,
-    proof: Vector,
-    queryRand: Vector,
-    jointRand: Vector,
+    input: bigint[],
+    proof: bigint[],
+    queryRand: bigint[],
+    jointRand: bigint[],
     shares: number
-  ): Vector;
+  ): bigint[];
 
-  decide(input: Vector): boolean;
+  decide(input: bigint[]): boolean;
 
-  truncate(input: Vector): Vector;
+  truncate(input: bigint[]): bigint[];
 }

--- a/src/prio3/gadget.ts
+++ b/src/prio3/gadget.ts
@@ -1,12 +1,12 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 
 export abstract class Gadget {
   abstract arity: number;
   abstract degree: number;
-  abstract eval(field: Field, input: Vector): bigint;
-  abstract evalPoly(field: Field, inputPolynomial: Vector[]): Vector;
+  abstract eval(field: Field, input: bigint[]): bigint;
+  abstract evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[];
 
-  ensureArity(input: Vector) {
+  ensureArity(input: bigint[]) {
     if (input.length !== this.arity) {
       throw new Error(
         `expected gadget input length (${input.length}) to equal arity (${this.arity}), but it did not`
@@ -14,7 +14,7 @@ export abstract class Gadget {
     }
   }
 
-  ensurePolyArity(inputPoly: Vector[]) {
+  ensurePolyArity(inputPoly: bigint[][]) {
     if (
       inputPoly.length !== this.arity ||
       inputPoly.find((p) => p.length !== inputPoly[0].length)

--- a/src/prio3/gadgets/mul.ts
+++ b/src/prio3/gadgets/mul.ts
@@ -1,16 +1,16 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { Gadget } from "prio3/gadget";
 
 export class Mul extends Gadget {
   arity = 2;
   degree = 2;
 
-  eval(field: Field, input: Vector): bigint {
+  eval(field: Field, input: bigint[]): bigint {
     this.ensureArity(input);
-    return field.mul(input.getValue(0), input.getValue(1));
+    return field.mul(input[0], input[1]);
   }
 
-  evalPoly(field: Field, inputPolynomial: Vector[]): Vector {
+  evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[] {
     this.ensurePolyArity(inputPolynomial);
     return field.mulPolys(inputPolynomial[0], inputPolynomial[1]);
   }

--- a/src/prio3/gadgets/polyEval.ts
+++ b/src/prio3/gadgets/polyEval.ts
@@ -28,7 +28,7 @@ export class PolyEval extends Gadget {
   eval(field: Field, input: bigint[]): bigint {
     this.ensureArity(input);
 
-    return field.evalPoly(field.vec(this.polynomial), input[0]);
+    return field.evalPoly(this.polynomial, input[0]);
   }
 
   evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[] {
@@ -47,6 +47,6 @@ export class PolyEval extends Gadget {
       x = field.mulPolys(x, inputPolynomial[0]);
     }
 
-    return field.vec(stripPolynomial(out));
+    return stripPolynomial(out);
   }
 }

--- a/src/prio3/gadgets/polyEval.ts
+++ b/src/prio3/gadgets/polyEval.ts
@@ -1,4 +1,4 @@
-import { arr } from "common";
+import { fill } from "common";
 import { Field } from "field";
 import { Gadget } from "prio3/gadget";
 
@@ -34,7 +34,7 @@ export class PolyEval extends Gadget {
   evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[] {
     this.ensurePolyArity(inputPolynomial);
 
-    const out = arr(this.degree * inputPolynomial[0].length, () => 0n);
+    const out = fill(this.degree * inputPolynomial[0].length, 0n);
     out[0] = this.polynomial[0];
 
     let x = inputPolynomial[0];

--- a/src/prio3/gadgets/polyEval.ts
+++ b/src/prio3/gadgets/polyEval.ts
@@ -1,5 +1,5 @@
 import { arr } from "common";
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { Gadget } from "prio3/gadget";
 
 function stripPolynomial(polynomial: bigint[]): bigint[] {
@@ -25,13 +25,13 @@ export class PolyEval extends Gadget {
     this.degree = polynomial.length - 1;
   }
 
-  eval(field: Field, input: Vector): bigint {
+  eval(field: Field, input: bigint[]): bigint {
     this.ensureArity(input);
 
-    return field.evalPoly(field.vec(this.polynomial), input.getValue(0));
+    return field.evalPoly(field.vec(this.polynomial), input[0]);
   }
 
-  evalPoly(field: Field, inputPolynomial: Vector[]): Vector {
+  evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[] {
     this.ensurePolyArity(inputPolynomial);
 
     const out = arr(this.degree * inputPolynomial[0].length, () => 0n);
@@ -41,10 +41,7 @@ export class PolyEval extends Gadget {
 
     for (let i = 1; i < this.polynomial.length; i++) {
       for (let j = 0; j < x.length; j++) {
-        out[j] = field.add(
-          out[j],
-          field.mul(this.polynomial[i], x.getValue(j))
-        );
+        out[j] = field.add(out[j], field.mul(this.polynomial[i], x[j]));
       }
 
       x = field.mulPolys(x, inputPolynomial[0]);

--- a/src/prio3/gadgets/proof.ts
+++ b/src/prio3/gadgets/proof.ts
@@ -1,5 +1,5 @@
 import { Field } from "field";
-import { arr, nextPowerOf2 } from "common";
+import { arr, fill, nextPowerOf2 } from "common";
 import { Gadget } from "prio3/gadget";
 
 export class Proof extends Gadget {
@@ -13,7 +13,7 @@ export class Proof extends Gadget {
     const wirePolyLength = nextPowerOf2(1 + calls);
     this.wire = arr(this.arity, (i) => [
       wireSeeds[i],
-      ...arr(wirePolyLength - 1, () => 0n),
+      ...fill(wirePolyLength - 1, 0n),
     ]);
   }
 

--- a/src/prio3/gadgets/proof.ts
+++ b/src/prio3/gadgets/proof.ts
@@ -1,4 +1,4 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { arr, nextPowerOf2 } from "common";
 import { Gadget } from "prio3/gadget";
 
@@ -17,17 +17,17 @@ export class Proof extends Gadget {
     ]);
   }
 
-  eval(field: Field, input: Vector): bigint {
+  eval(field: Field, input: bigint[]): bigint {
     this.callCount += 1;
 
     this.wire.forEach((wire, index) => {
-      wire[this.callCount] = input.getValue(index);
+      wire[this.callCount] = input[index];
     });
 
     return this.gadget.eval(field, input);
   }
 
-  evalPoly(field: Field, inputPoly: Vector[]): Vector {
+  evalPoly(field: Field, inputPoly: bigint[][]): bigint[] {
     return this.gadget.evalPoly(field, inputPoly);
   }
 

--- a/src/prio3/gadgets/query.ts
+++ b/src/prio3/gadgets/query.ts
@@ -1,18 +1,18 @@
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { nextPowerOf2, arr } from "common";
 import { Gadget } from "prio3/gadget";
 
 export class Query extends Gadget {
   wire: bigint[][];
   gadget: Gadget;
-  gadgetPoly: Vector;
+  gadgetPoly: bigint[];
   alpha: bigint;
   callCount = 0;
 
   constructor(
     field: Field,
     wireSeeds: bigint[],
-    gadgetPoly: Vector,
+    gadgetPoly: bigint[],
     gadget: Gadget,
     calls: number
   ) {
@@ -32,11 +32,11 @@ export class Query extends Gadget {
     );
   }
 
-  eval(field: Field, input: Vector): bigint {
+  eval(field: Field, input: bigint[]): bigint {
     this.callCount += 1;
 
     this.wire.forEach((wire, index) => {
-      wire[this.callCount] = input.getValue(index);
+      wire[this.callCount] = input[index];
     });
 
     return field.evalPoly(
@@ -45,7 +45,7 @@ export class Query extends Gadget {
     );
   }
 
-  evalPoly(_field: Field, _inputPoly: unknown): Vector {
+  evalPoly(_field: Field, _inputPoly: unknown): bigint[] {
     throw new Error("evalPoly is not implemented for QueryGadget");
   }
 

--- a/src/prio3/gadgets/query.ts
+++ b/src/prio3/gadgets/query.ts
@@ -1,5 +1,5 @@
 import { Field } from "field";
-import { nextPowerOf2, arr } from "common";
+import { nextPowerOf2, arr, fill } from "common";
 import { Gadget } from "prio3/gadget";
 
 export class Query extends Gadget {
@@ -23,7 +23,7 @@ export class Query extends Gadget {
 
     this.wire = arr(this.arity, (i) => [
       wireSeeds[i],
-      ...arr(wirePolyLength - 1, () => 0n),
+      ...fill(wirePolyLength - 1, 0n),
     ]);
 
     this.alpha = field.exp(

--- a/src/prio3/genericFlp.spec.ts
+++ b/src/prio3/genericFlp.spec.ts
@@ -1,5 +1,5 @@
 import { Gadget } from "prio3/gadget";
-import { Vector, Field, Field128, Field64 } from "field";
+import { Field, Field128, Field64 } from "field";
 import { Count } from "prio3/circuits/count";
 import { Sum } from "prio3/circuits/sum";
 import { Histogram } from "prio3/circuits/histogram";
@@ -29,7 +29,11 @@ function testCircuitGadgets(circuit: GenericCircuit) {
   });
 }
 
-function testCircuit<M>(circuit: Circuit<M>, input: Vector, expected: boolean) {
+function testCircuit<M>(
+  circuit: Circuit<M>,
+  input: bigint[],
+  expected: boolean
+) {
   assert.equal(input.length, circuit.inputLen);
   assert.equal(circuit.truncate(input).length, circuit.outputLen);
   const jointRand = circuit.field.fillRandom(circuit.jointRandLen);
@@ -47,24 +51,24 @@ class TestMultiGadget extends Circuit<number> {
   jointRandLen = 0;
   outputLen = 1;
 
-  eval(input: Vector, jointRand: Vector, _shares: number): bigint {
+  eval(input: bigint[], jointRand: bigint[], _shares: number): bigint {
     this.ensureValidEval(input, jointRand);
     const field = this.field;
     const [g0, g1] = this.gadgets;
-    const x = g0.eval(field, field.vec([input.getValue(0), input.getValue(0)]));
-    const y = g1.eval(field, field.vec([input.getValue(0), x]));
+    const x = g0.eval(field, field.vec([input[0], input[0]]));
+    const y = g1.eval(field, field.vec([input[0], x]));
     const z = g1.eval(field, field.vec([x, y]));
     return z;
   }
 
-  encode(measurement: number): Vector {
+  encode(measurement: number): bigint[] {
     if (![0, 1].includes(measurement)) {
       throw new Error("measurement expected to be 1 or 0");
     }
     return this.field.vec([BigInt(measurement)]);
   }
 
-  truncate(input: Vector): Vector {
+  truncate(input: bigint[]): bigint[] {
     if (input.length !== 1) {
       throw new Error("expected input length to be 1");
     }

--- a/src/prio3/genericFlp.spec.ts
+++ b/src/prio3/genericFlp.spec.ts
@@ -16,7 +16,7 @@ function testGadget(gadget: Gadget, field: Field, testLength: number) {
   const inputPoly = arr(gadget.arity, () => field.fillRandom(testLength));
   const input = inputPoly.map((poly) => field.evalPoly(poly, evalAt));
   const outPoly = gadget.evalPoly(field, inputPoly);
-  const expected = gadget.eval(field, field.vec(input));
+  const expected = gadget.eval(field, input);
   const actual = field.evalPoly(outPoly, evalAt);
 
   assert.equal(actual, expected);
@@ -55,9 +55,9 @@ class TestMultiGadget extends Circuit<number> {
     this.ensureValidEval(input, jointRand);
     const field = this.field;
     const [g0, g1] = this.gadgets;
-    const x = g0.eval(field, field.vec([input[0], input[0]]));
-    const y = g1.eval(field, field.vec([input[0], x]));
-    const z = g1.eval(field, field.vec([x, y]));
+    const x = g0.eval(field, [input[0], input[0]]);
+    const y = g1.eval(field, [input[0], x]);
+    const z = g1.eval(field, [x, y]);
     return z;
   }
 
@@ -65,7 +65,7 @@ class TestMultiGadget extends Circuit<number> {
     if (![0, 1].includes(measurement)) {
       throw new Error("measurement expected to be 1 or 0");
     }
-    return this.field.vec([BigInt(measurement)]);
+    return [BigInt(measurement)];
   }
 
   truncate(input: bigint[]): bigint[] {
@@ -87,7 +87,7 @@ describe("flp generic", () => {
     it("examples", () => {
       testCircuit(count, count.encode(false), true);
       testCircuit(count, count.encode(true), true);
-      testCircuit(count, count.field.vec([1337n]), false);
+      testCircuit(count, [1337n], false);
     });
   });
 

--- a/src/prio3/index.ts
+++ b/src/prio3/index.ts
@@ -1,6 +1,6 @@
 import { Vdaf, VDAF_VERSION } from "vdaf";
 import { PrgConstructor } from "prng";
-import { arr, xor, split, xorInPlace } from "common";
+import { fill, arr, xor, split, xorInPlace } from "common";
 import { Field } from "field";
 import { Flp } from "prio3/flp";
 
@@ -201,7 +201,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
 
         return field.vecAdd(verifier, shareVerifier);
       },
-      arr(flp.verifierLen, () => 0n)
+      fill(flp.verifierLen, 0n)
     );
 
     return this.encodePrepareMessage(verifier, jointRandCheck);
@@ -214,7 +214,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
     const { field, flp } = this;
     return outShares.reduce(
       (agg, share) => field.vecAdd(agg, share),
-      arr(flp.outputLen, () => 0n)
+      fill(flp.outputLen, 0n)
     );
   }
 
@@ -224,10 +224,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
   ): AggregationResult {
     const { field, flp } = this;
     return aggShares
-      .reduce(
-        (agg, share) => field.vecAdd(agg, share),
-        arr(flp.outputLen, () => 0n)
-      )
+      .reduce((agg, share) => field.vecAdd(agg, share), fill(flp.outputLen, 0n))
       .map(Number);
   }
 

--- a/src/prio3/index.ts
+++ b/src/prio3/index.ts
@@ -137,7 +137,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
       jointRandSeed = xor(share.hint, shareJointRandSeed);
       jointRand = await this.pseudorandom(flp.jointRandLen, jointRandSeed);
     } else {
-      jointRand = field.vec([]);
+      jointRand = [];
       jointRandSeed = null;
       shareJointRandSeed = null;
     }
@@ -192,8 +192,6 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
 
     const verifier = encodedPrepShares.reduce(
       (verifier, encodedPrepMessage) => {
-        field.vec(flp.verifierLen);
-
         const { verifier: shareVerifier, jointRand: shareJointRand } =
           this.decodePrepareMessage(encodedPrepMessage);
 
@@ -203,7 +201,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
 
         return field.vecAdd(verifier, shareVerifier);
       },
-      field.vec(flp.verifierLen)
+      arr(flp.verifierLen, () => 0n)
     );
 
     return this.encodePrepareMessage(verifier, jointRandCheck);
@@ -216,7 +214,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
     const { field, flp } = this;
     return outShares.reduce(
       (agg, share) => field.vecAdd(agg, share),
-      field.vec(flp.outputLen)
+      arr(flp.outputLen, () => 0n)
     );
   }
 
@@ -228,7 +226,7 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
     return aggShares
       .reduce(
         (agg, share) => field.vecAdd(agg, share),
-        field.vec(flp.outputLen)
+        arr(flp.outputLen, () => 0n)
       )
       .map(Number);
   }

--- a/src/prng.spec.ts
+++ b/src/prng.spec.ts
@@ -97,6 +97,6 @@ describe("PrgAes128", () => {
       info,
       expandedLen
     );
-    assert.equal(expandedVec.getValue(expandedLen - 1), expectedLastElem);
+    assert.equal(expandedVec[expandedLen - 1], expectedLastElem);
   });
 });

--- a/src/prng.ts
+++ b/src/prng.ts
@@ -1,5 +1,5 @@
 import { AesCmac } from "aes-cmac";
-import { Field, Vector } from "field";
+import { Field } from "field";
 import { nextPowerOf2Big, randomBytes } from "common";
 import { octetStringToInteger } from "common";
 import * as crypto from "crypto";
@@ -33,7 +33,7 @@ export abstract class Prg {
     seed: Buffer,
     info: Buffer,
     length: number
-  ): Promise<Vector> {
+  ): Promise<bigint[]> {
     const m = nextPowerOf2Big(field.modulus) - 1n;
     const prg = new this(seed, info);
     const vec = [];
@@ -57,7 +57,7 @@ export interface PrgConstructor {
     seed: Buffer,
     info: Buffer,
     length: number
-  ): Promise<Vector>;
+  ): Promise<bigint[]>;
 }
 
 /**

--- a/src/prng.ts
+++ b/src/prng.ts
@@ -43,7 +43,7 @@ export abstract class Prg {
         vec.push(x);
       }
     }
-    return field.vec(vec);
+    return vec;
   }
 }
 

--- a/src/vdaf.spec.ts
+++ b/src/vdaf.spec.ts
@@ -67,8 +67,8 @@ export class VdafTest implements TestVdaf {
     );
 
     return Promise.resolve([
-      field.encode(field.vec([leaderShare])),
-      ...helperShares.map((hs) => field.encode(field.vec([hs]))),
+      field.encode([leaderShare]),
+      ...helperShares.map((hs) => field.encode([hs])),
     ]);
   }
 
@@ -109,16 +109,16 @@ export class VdafTest implements TestVdaf {
     prepShares: Buffer[]
   ): Buffer {
     const { field } = this;
-    return field.encode(
-      field.vec([field.sum(prepShares, (encoded) => field.decode(encoded)[0])])
-    );
+    return field.encode([
+      field.sum(prepShares, (encoded) => field.decode(encoded)[0]),
+    ]);
   }
 
   outputSharesToAggregatorShare(
     _aggParam: null,
     outShares: bigint[][]
   ): bigint[] {
-    return this.field.vec([this.field.sum(outShares, (share) => share[0])]);
+    return [this.field.sum(outShares, (share) => share[0])];
   }
 
   aggregatorSharesToResult(


### PR DESCRIPTION
This serves two purposes:
* hides the galois field library implementation from public interfaces, preparing us to potentially switch out the library if needed, either now or at some future point
* eliminates round-tripping short bigint arrays through Vector unnecessarily