### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/src/dap/client.ts
+++ b/src/dap/client.ts
@@ -306,7 +306,7 @@ export class DAPClient<
         if (!response.ok) {
           throw await DAPError.fromResponse(
             response,
-            `makeKeyConfigurationRequest received a ${response.status} response, aborting`
+            `fetchKeyConfiguration received a ${response.status} response, aborting`
           );
         }
 

--- a/src/dap/client.ts
+++ b/src/dap/client.ts
@@ -177,10 +177,8 @@ export class DAPClient<
   /**
      Produce a {@linkcode Report} from the supplied Measurement
      
-     This method depends on the key configuration already having been
-     fetched with {@linkcode DAPClient.fetchKeyConfiguration}. It will
-     throw an error if you attempt to call it without having
-     previously fetched key configuration.
+     This may make network requests to fetch key configuration from the
+     leader and helper, if needed.
 
      @param measurement The type of this argument will be determined
      by the Vdaf that this client is constructed for.
@@ -251,9 +249,10 @@ export class DAPClient<
      needed), generate a report from the provided measurement and send
      that report to the leader aggregator.
 
-     This is identical to calling {@linkcode
-     DAPClient.fetchKeyConfiguration}, {@linkcode
-     DAPClient.generateReport}, and {@linkcode DAPClient.sendReport}.
+     This will call {@linkcode DAPClient.generateReport} and
+     {@linkcode DAPClient.sendReport}, while automatically handling
+     any errors due to server key rotation with re-encryption and a
+     retry.
 
      @throws {@linkcode DAPError} if any http response is not Ok or
      `Error` if there is an issue generating the report

--- a/src/field.spec.ts
+++ b/src/field.spec.ts
@@ -28,7 +28,7 @@ function testField(field: Field, name: string) {
       });
     });
 
-    it("does not decode when the field is not a multiple of encodedSize", () => {
+    it("does not decode when the input length is not a multiple of encodedSize", () => {
       const oneByteTooLong = Buffer.alloc(field.encodedSize + 1, 10);
       assert.throws(() => field.decode(oneByteTooLong));
 

--- a/src/prio3/gadgets/polyEval.ts
+++ b/src/prio3/gadgets/polyEval.ts
@@ -34,7 +34,7 @@ export class PolyEval extends Gadget {
   evalPoly(field: Field, inputPolynomial: bigint[][]): bigint[] {
     this.ensurePolyArity(inputPolynomial);
 
-    const out = fill(this.degree * inputPolynomial[0].length, 0n);
+    const out = fill(this.degree * (inputPolynomial[0].length - 1) + 1, 0n);
     out[0] = this.polynomial[0];
 
     let x = inputPolynomial[0];

--- a/src/prio3/index.ts
+++ b/src/prio3/index.ts
@@ -264,12 +264,12 @@ export class Prio3<Measurement> implements Prio3Vdaf<Measurement> {
 
   private encodePrepareMessage(
     verifier: bigint[],
-    jointRandShares: Buffer | null
+    jointRandShare: Buffer | null
   ): Buffer {
     const verifierEncoded = this.field.encode(verifier);
 
-    if (this.flp.jointRandLen > 0 && jointRandShares) {
-      return Buffer.concat([verifierEncoded, jointRandShares]);
+    if (this.flp.jointRandLen > 0 && jointRandShare) {
+      return Buffer.concat([verifierEncoded, jointRandShare]);
     } else {
       return verifierEncoded;
     }


### PR DESCRIPTION
This rolls up a handful of fixes I caught while reviewing the codebase. Most of them are documentation or names, the only substantive change is in the PolyEval gadget. (The polynomial degree of the composition of two polynomials is equal to the product of the degrees of the two polynomials, because the highest degree term will be like so: $y=x^a, z=y^b \implies z=(x^a)^b=x^{ab}$. All that's left is $\pm1$ to convert between degrees and number of polynomial coefficients.)