### PR TITLE
Export dap module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from "prio3/circuits/histogram";
 export * from "prio3/flp";
 export * from "prio3/genericFlp";
 export * from "prio3/gadget";
+export * from "dap";


### PR DESCRIPTION
I think we may need to export the "dap" module from our main file. While it shows up in our documentation already, I wasn't able to import it, and the compiled .js file did not include a reexport for it.