### PR TITLE
Update domain separation tag for VDAF draft 01

### DIFF
--- a/src/vdaf.ts
+++ b/src/vdaf.ts
@@ -1,5 +1,5 @@
 /** @internal */
-export const VDAF_VERSION = "vdaf-00";
+export const VDAF_VERSION = "vdaf-01";
 
 export interface Vdaf<
   Measurement,


### PR DESCRIPTION
This updates the VDAF draft number in the domain separation tag. This is needed for DAP draft-01 compatibility.