### PR TITLE
Nonce changes for draft-ietf-ppm-dap-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ const client = new DAPClient({
   taskId: "3XTBHxTtUAtI516GeXZsVIKjBPYVNIYmF94vEBb4jcY",
   leader: "http://localhost:8080",
   helper: "http://localhost:8081",
+  minBatchDurationSeconds: 3600,
 });
 
 await client.sendMeasurement(42);

--- a/scripts/benchmarks.ts
+++ b/scripts/benchmarks.ts
@@ -34,6 +34,7 @@ function buildClient<
       helper: "http://helper.example.com",
       leader: "http://leader.example.com",
       taskId: TaskId.random(),
+      minBatchDurationSeconds: 1,
       ...spec,
     })
   );

--- a/scripts/liveTest.ts
+++ b/scripts/liveTest.ts
@@ -6,6 +6,7 @@ async function main() {
     helper: "http://localhost:8081",
     type: "histogram",
     buckets: [10, 20, 30],
+    minBatchDurationSeconds: 8 * 3600,
   });
 
   await client.sendMeasurement(1);

--- a/src/dap/client.spec.ts
+++ b/src/dap/client.spec.ts
@@ -59,6 +59,7 @@ function buildParams(): {
   helper: string;
   leader: string;
   taskId: TaskId;
+  minBatchDurationSeconds: number;
 } {
   return {
     type: "sum",
@@ -66,6 +67,7 @@ function buildParams(): {
     leader: "https://a.example.com",
     helper: "https://b.example.com",
     taskId: TaskId.random(),
+    minBatchDurationSeconds: 1,
   };
 }
 
@@ -114,6 +116,7 @@ describe("DAPClient", () => {
         helper: "http://helper",
         leader: "http://leader",
         taskId: "3XTBHxTtUAtI516GeXZsVIKjBPYVNIYmF94vEBb4jcY",
+        minBatchDurationSeconds: 3600,
       });
 
       assert(client.vdaf instanceof Prio3Aes128Histogram);
@@ -126,6 +129,7 @@ describe("DAPClient", () => {
         helper: "http://helper",
         leader: "http://leader",
         taskId: "3XTBHxTtUAtI516GeXZsVIKjBPYVNIYmF94vEBb4jcY",
+        minBatchDurationSeconds: 3600,
       });
 
       assert(client.vdaf instanceof Prio3Aes128Sum);
@@ -138,6 +142,7 @@ describe("DAPClient", () => {
         helper: "http://helper",
         leader: "http://leader",
         taskId: "3XTBHxTtUAtI516GeXZsVIKjBPYVNIYmF94vEBb4jcY",
+        minBatchDurationSeconds: 3600,
       });
 
       assert(client.vdaf instanceof Prio3Aes128Count);
@@ -253,7 +258,7 @@ describe("DAPClient", () => {
       assert.equal(report.taskID, client.taskId);
       assert(
         Math.floor(Date.now() / 1000) - Number(report.nonce.time) <
-          1 /*1 second delta*/
+          2 /*2 second delta, double the minimum batch duration*/
       );
 
       const aad = Buffer.from([

--- a/src/dap/nonce.spec.ts
+++ b/src/dap/nonce.spec.ts
@@ -10,24 +10,27 @@ describe("DAP Nonce", () => {
   });
 
   describe("construction", () => {
-    it("throws an error if rand is not exactly 8 bytes", () => {
-      assert.throws(() => new Nonce(BigInt(0), Buffer.alloc(7)));
-      assert.doesNotThrow(() => new Nonce(BigInt(0), Buffer.alloc(8)));
-      assert.throws(() => new Nonce(BigInt(0), Buffer.alloc(9)));
+    it("throws an error if rand is not exactly 16 bytes", () => {
+      assert.throws(() => new Nonce(BigInt(0), Buffer.alloc(15)));
+      assert.doesNotThrow(() => new Nonce(BigInt(0), Buffer.alloc(16)));
+      assert.throws(() => new Nonce(BigInt(0), Buffer.alloc(17)));
     });
   });
 
   describe("encode", () => {
-    it("writes 8 bytes of time and 8 bytes of rand", () => {
+    it("writes 8 bytes of time and 16 bytes of rand", () => {
       const date = BigInt(1000);
-      const rand = Buffer.alloc(8, 255);
+      const rand = Buffer.alloc(16, 255);
       const nonce = new Nonce(date, rand);
 
       assert.deepEqual(
         nonce.encode(),
         Buffer.from([
           ...[0, 0, 0, 0, 0, 0, 3, 232],
-          ...[255, 255, 255, 255, 255, 255, 255, 255],
+          ...[
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255,
+          ],
         ])
       );
     });

--- a/src/dap/nonce.spec.ts
+++ b/src/dap/nonce.spec.ts
@@ -3,9 +3,18 @@ import assert from "assert";
 
 describe("DAP Nonce", () => {
   describe("generate", () => {
-    it("uses the current time in seconds as the first component", () => {
-      const nonce = Nonce.generate();
-      assert(Date.now() / 1000 - Number(nonce.time) < 500); // 500ms of delta
+    it("uses the current batch start time in seconds as the first component", () => {
+      for (const minBatchDurationSeconds of [1, 3600, 3600 * 24]) {
+        const nonce = Nonce.generate(minBatchDurationSeconds);
+        // Check that the nonce time is a multiple of the minimum batch
+        // duration.
+        assert(Number(nonce.time % BigInt(minBatchDurationSeconds)) == 0);
+        // Check that the nonce time is no older than one batch interval plus
+        // 500ms of slop.
+        assert(
+          Date.now() / 1000 - Number(nonce.time) < minBatchDurationSeconds + 0.5
+        );
+      }
     });
   });
 

--- a/src/dap/nonce.ts
+++ b/src/dap/nonce.ts
@@ -3,14 +3,19 @@ import { randomBytes } from "common";
 
 export class Nonce implements Encodable {
   constructor(public time: bigint, public rand: Buffer) {
-    // TODO: round time down to batch size
     if (rand.length !== 16) {
       throw new Error("rand must be 16 bytes");
     }
   }
 
-  static generate(): Nonce {
-    return new Nonce(BigInt(Math.floor(Date.now() / 1000)), randomBytes(16));
+  static generate(minBatchDurationSeconds: number): Nonce {
+    return new Nonce(
+      BigInt(
+        Math.floor(Date.now() / 1000 / minBatchDurationSeconds) *
+          minBatchDurationSeconds
+      ),
+      randomBytes(16)
+    );
   }
 
   encode(): Buffer {

--- a/src/dap/nonce.ts
+++ b/src/dap/nonce.ts
@@ -3,19 +3,20 @@ import { randomBytes } from "common";
 
 export class Nonce implements Encodable {
   constructor(public time: bigint, public rand: Buffer) {
-    if (rand.length !== 8) {
-      throw new Error("rand must be 8 bytes");
+    // TODO: round time down to batch size
+    if (rand.length !== 16) {
+      throw new Error("rand must be 16 bytes");
     }
   }
 
   static generate(): Nonce {
-    return new Nonce(BigInt(Math.floor(Date.now() / 1000)), randomBytes(8));
+    return new Nonce(BigInt(Math.floor(Date.now() / 1000)), randomBytes(16));
   }
 
   encode(): Buffer {
-    const buffer = Buffer.alloc(16);
+    const buffer = Buffer.alloc(24);
     buffer.writeBigInt64BE(this.time, 0);
-    this.rand.copy(buffer, 8, 0, 8);
+    this.rand.copy(buffer, 8, 0, 16);
     return buffer;
   }
 }

--- a/src/dap/report.spec.ts
+++ b/src/dap/report.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 describe("DAP Report", () => {
   it("encodes as expected", () => {
     const taskId = TaskId.random();
-    const nonce = Nonce.generate();
+    const nonce = Nonce.generate(3600);
 
     const ciphertext1 = new HpkeCiphertext(
       1,


### PR DESCRIPTION
This adopts changes to the `Nonce` structure in draft 01 of the DAP spec. The randomness component is doubled to 16 bytes long, and the time component is changed from being the time of report submission to the corresponding batch interval start time.

This closes #63.