### PR TITLE
add an optional argument to specify nonce timestamp in report generation

### DIFF
--- a/packages/dap/src/client.spec.ts
+++ b/packages/dap/src/client.spec.ts
@@ -229,6 +229,7 @@ describe("DAPClient", () => {
       assert.equal(fetch.calls.length, 2);
     });
   });
+
   describe("generating reports", () => {
     it("can succeed", async () => {
       const privateKeys = [] as [Buffer, number][];
@@ -290,6 +291,17 @@ describe("DAPClient", () => {
           )
         );
       }
+    });
+
+    it("accepts an optional nonceTimestamp", async () => {
+      const client = withHpkeConfigs(new DAPClient(buildParams()));
+      const fetch = mockFetch({});
+      client.fetch = fetch;
+      const nonceTimestamp = new Date(0);
+      const report = await client.generateReport(1, {
+        nonceTimestamp,
+      });
+      assert.equal(report.nonce.time, nonceTimestamp.getTime());
     });
 
     it("fails if the measurement is not valid", async () => {

--- a/packages/dap/src/nonce.ts
+++ b/packages/dap/src/nonce.ts
@@ -9,12 +9,12 @@ export class Nonce implements Encodable {
     }
   }
 
-  static generate(minBatchDurationSeconds: number): Nonce {
-    return new Nonce(
-      Math.floor(Date.now() / 1000 / minBatchDurationSeconds) *
-        minBatchDurationSeconds,
-      randomBytes(16)
-    );
+  static generate(minBatchDurationSeconds: number, date?: Date): Nonce {
+    const epochSeconds = (date ? date.getTime() : Date.now()) / 1000;
+    const batchRoundedSeconds =
+      Math.floor(epochSeconds / minBatchDurationSeconds) *
+      minBatchDurationSeconds;
+    return new Nonce(batchRoundedSeconds, randomBytes(16));
   }
 
   encode(): Buffer {


### PR DESCRIPTION
closes #97 

Note: I opted to use an object for the additional optional argument to report generation so that if there are future optional options/configs they can be added into that object. At the moment with only one field/property it's a little awkward, but it allows us to add additional arguments as a semver-patch-level change