### PR TITLE
Replace local path dependencies with versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14224,13 +14224,13 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "../common",
-        "@divviup/prio3": "../prio3",
-        "@divviup/vdaf": "../vdaf",
+        "@divviup/common": "^0.1.0",
+        "@divviup/prio3": "^0.1.0",
+        "@divviup/vdaf": "^0.1.0",
         "hpke": "^0.4.0"
       },
       "devDependencies": {
-        "@divviup/prg": "../prg",
+        "@divviup/prg": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/expect": "^24.3.0",
@@ -14263,7 +14263,7 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "../common",
+        "@divviup/common": "^0.1.0",
         "one-webcrypto": "^1.0.3"
       },
       "devDependencies": {
@@ -14295,8 +14295,8 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "../common",
-        "@divviup/field": "../field",
+        "@divviup/common": "^0.1.0",
+        "@divviup/field": "^0.1.0",
         "aes-cmac": "^2.0.x",
         "one-webcrypto": "^1.0.3"
       },
@@ -14328,10 +14328,10 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "../common",
-        "@divviup/field": "../field",
-        "@divviup/prg": "../prg",
-        "@divviup/vdaf": "../vdaf",
+        "@divviup/common": "^0.1.0",
+        "@divviup/field": "^0.1.0",
+        "@divviup/prg": "^0.1.0",
+        "@divviup/vdaf": "^0.1.0",
         "buffer": "^6.0.3"
       },
       "devDependencies": {
@@ -14362,11 +14362,11 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "../common",
+        "@divviup/common": "^0.1.0",
         "assert": "^2.0.0"
       },
       "devDependencies": {
-        "@divviup/prg": "../prg",
+        "@divviup/prg": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/assert": "^1.5.6",
@@ -14760,10 +14760,10 @@
     "@divviup/dap": {
       "version": "file:packages/dap",
       "requires": {
-        "@divviup/common": "../common",
-        "@divviup/prg": "../prg",
-        "@divviup/prio3": "../prio3",
-        "@divviup/vdaf": "../vdaf",
+        "@divviup/common": "^0.1.0",
+        "@divviup/prg": "^0.1.0",
+        "@divviup/prio3": "^0.1.0",
+        "@divviup/vdaf": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/expect": "^24.3.0",
@@ -14797,7 +14797,7 @@
     "@divviup/field": {
       "version": "file:packages/field",
       "requires": {
-        "@divviup/common": "../common",
+        "@divviup/common": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/chai": "^4.3.3",
@@ -14825,8 +14825,8 @@
     "@divviup/prg": {
       "version": "file:packages/prg",
       "requires": {
-        "@divviup/common": "../common",
-        "@divviup/field": "../field",
+        "@divviup/common": "^0.1.0",
+        "@divviup/field": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@parcel/transformer-typescript-types": "^2.7.0",
         "@tsconfig/node18": "^1.0.1",
@@ -14854,10 +14854,10 @@
     "@divviup/prio3": {
       "version": "file:packages/prio3",
       "requires": {
-        "@divviup/common": "../common",
-        "@divviup/field": "../field",
-        "@divviup/prg": "../prg",
-        "@divviup/vdaf": "../vdaf",
+        "@divviup/common": "^0.1.0",
+        "@divviup/field": "^0.1.0",
+        "@divviup/prg": "^0.1.0",
+        "@divviup/vdaf": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/expect": "^24.3.0",
@@ -14884,8 +14884,8 @@
     "@divviup/vdaf": {
       "version": "file:packages/vdaf",
       "requires": {
-        "@divviup/common": "../common",
-        "@divviup/prg": "../prg",
+        "@divviup/common": "^0.1.0",
+        "@divviup/prg": "^0.1.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@tsconfig/node18": "^1.0.1",
         "@types/assert": "^1.5.6",

--- a/packages/dap/package.json
+++ b/packages/dap/package.json
@@ -21,13 +21,13 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "../common",
-    "@divviup/prio3": "../prio3",
-    "@divviup/vdaf": "../vdaf",
+    "@divviup/common": "^0.1.0",
+    "@divviup/prio3": "^0.1.0",
+    "@divviup/vdaf": "^0.1.0",
     "hpke": "^0.4.0"
   },
   "devDependencies": {
-    "@divviup/prg": "../prg",
+    "@divviup/prg": "^0.1.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@tsconfig/node18": "^1.0.1",
     "@types/expect": "^24.3.0",

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "../common",
+    "@divviup/common": "^0.1.0",
     "one-webcrypto": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/prg/package.json
+++ b/packages/prg/package.json
@@ -18,8 +18,8 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "../common",
-    "@divviup/field": "../field",
+    "@divviup/common": "^0.1.0",
+    "@divviup/field": "^0.1.0",
     "aes-cmac": "^2.0.x",
     "one-webcrypto": "^1.0.3"
   },

--- a/packages/prio3/package.json
+++ b/packages/prio3/package.json
@@ -19,10 +19,10 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "../common",
-    "@divviup/field": "../field",
-    "@divviup/prg": "../prg",
-    "@divviup/vdaf": "../vdaf",
+    "@divviup/common": "^0.1.0",
+    "@divviup/field": "^0.1.0",
+    "@divviup/prg": "^0.1.0",
+    "@divviup/vdaf": "^0.1.0",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/vdaf/package.json
+++ b/packages/vdaf/package.json
@@ -18,11 +18,11 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "../common",
+    "@divviup/common": "^0.1.0",
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@divviup/prg": "../prg",
+    "@divviup/prg": "^0.1.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@tsconfig/node18": "^1.0.1",
     "@types/assert": "^1.5.6",


### PR DESCRIPTION
This rewrites all local path dependencies to instead use versions.

This fixes `nx graph`, and I suspect this change is also needed prior to publishing.