### PR TITLE
Configure Nx target dependencies, redo `ci` script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,7 @@ jobs:
       with:
         node-version: 18
     - run: npm ci
-    - run: npm run build
-    - run: npm run lint
-    - run: npm run test:coverage
+    - run: npm run ci
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/nx.json
+++ b/nx.json
@@ -25,6 +25,9 @@
     "build": {
       "dependsOn": ["^build"]
     },
+    "lint": {
+      "dependsOn": ["build"]
+    },
     "test": {
       "dependsOn": ["build"]
     },

--- a/nx.json
+++ b/nx.json
@@ -24,6 +24,12 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    },
+    "test:coverage": {
+      "dependsOn": ["build"]
     }
   },
   "affected": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "lerna run test",
     "build": "lerna run build",
     "test:coverage": "rm -rf coverage && rm -rf .nyc_output && lerna run test:coverage",
-    "lint": "lerna run lint"
+    "lint": "lerna run lint",
+    "ci": "npm run lint && npm run test:coverage"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.7.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,8 +13,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/dap/package.json
+++ b/packages/dap/package.json
@@ -16,8 +16,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\"  -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -16,8 +16,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/prg/package.json
+++ b/packages/prg/package.json
@@ -13,8 +13,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/prio3/package.json
+++ b/packages/prio3/package.json
@@ -14,8 +14,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/vdaf/package.json
+++ b/packages/vdaf/package.json
@@ -13,8 +13,7 @@
     "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
     "lint": "eslint src --ext .ts && prettier -c src",
     "format": "prettier -w src",
-    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test",
-    "ci": "npm run lint && npm run test:coverage"
+    "test:coverage": "nyc --cwd=../.. --no-clean --reporter=lcov --reporter=text --reporter=json npm test"
   },
   "license": "MPL-2.0",
   "dependencies": {


### PR DESCRIPTION
This tells Nx that test targets depend on the build target, and then adds a `ci` lifecycle task in the top level package.

This has two benefits: `npm test` is now sufficient for local development (rather than running two commands) and we may shave a fraction of a second off by letting build and test tasks pipeline together.