### PR TITLE
Fix histogram and sum circuits

### DIFF
--- a/packages/prio3/src/circuits/histogram.ts
+++ b/packages/prio3/src/circuits/histogram.ts
@@ -28,7 +28,7 @@ export class Histogram extends Circuit<number> {
     const f = this.field;
 
     const rangeCheck = f.sum(input, (value, index) =>
-      f.mul(f.exp(firstRand, BigInt(index)), gadget.eval(f, [value]))
+      f.mul(f.exp(firstRand, BigInt(index + 1)), gadget.eval(f, [value]))
     );
 
     const sumCheck = f.sum(

--- a/packages/prio3/src/circuits/sum.ts
+++ b/packages/prio3/src/circuits/sum.ts
@@ -29,7 +29,7 @@ export class Sum extends Circuit<number | bigint> {
 
     return field.sum(input, (value, index) =>
       field.mul(
-        field.exp(jointRandZero, BigInt(index)),
+        field.exp(jointRandZero, BigInt(index + 1)),
         poly.eval(field, [value])
       )
     );


### PR DESCRIPTION
This fixes errors in the circuits for two of the Prio3 VDAFs. They were using the wrong powers of a joint randomness value in random linear combinations. (See https://www.ietf.org/archive/id/draft-irtf-cfrg-vdaf-01.html#section-7.4.2-7 and https://www.ietf.org/archive/id/draft-irtf-cfrg-vdaf-01.html#section-7.4.3-5)

Because the client only evaluates the circuit in order to record gadget wire inputs, and because these two circuits did not have any gadgets downstream of the incorrect random linear combinations, this change has no effect on proofs in reports. It does correct errors in test vector output, which includes the circuit's output value on shares, as part of preparation.