### PR TITLE
Export named dap client

### DIFF
--- a/packages/dap/src/index.ts
+++ b/packages/dap/src/index.ts
@@ -1,1 +1,1 @@
-export { DAPClient as default } from "./client";
+export { DAPClient, DAPClient as default } from "./client";


### PR DESCRIPTION
This may help address #89, in that at least now it will be `require("@divviup/dap").DAPClient`