### PR TITLE
Fix permissions of Docker CI action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,9 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
This grants `id-token` permissions to the Docker action, so that it can use the `google-github-actions/auth@v0` action.