### PR TITLE
Turn off unused env vars from google-github-auth

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,6 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-        export_environment_variables: true
     - id: "gcp-auth-public"
       name: Authenticate to GCP (public repository)
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -44,7 +43,6 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
-        export_environment_variables: true
     - name: Docker Login (private)
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       uses: "docker/login-action@v2"


### PR DESCRIPTION
This tells google-github-auth to not set environment variables (with the GCP project name, token file location, etc.). Since we only use the resulting token via an actions output, we don't need these environment variables. Additionally, this gets rid of some warnings from the second invocation, which reported that previously set environment variables were being overwritten.