### PR TITLE
Really turn off unused environment vars

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
+        export_environment_variables: false
     - id: "gcp-auth-public"
       name: Authenticate to GCP (public repository)
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -43,6 +44,7 @@ jobs:
         token_format: "access_token"
         access_token_lifetime: "3600s"
         access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
+        export_environment_variables: false
     - name: Docker Login (private)
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       uses: "docker/login-action@v2"


### PR DESCRIPTION
#134 was not effective, as the default value for `export_environment_variables` was also true. This explicitly sets the input to false.