### PR TITLE
Add length prefix before public share in AAD

### DIFF
--- a/packages/dap/src/client.spec.ts
+++ b/packages/dap/src/client.spec.ts
@@ -264,6 +264,7 @@ describe("DAPClient", () => {
       const aad = Buffer.from([
         ...fill(32, 1),
         ...report.metadata.encode(),
+        ...[0, 0, 0, 0], // length of empty public share
         ...report.publicShare,
       ]);
 

--- a/packages/dap/src/client.ts
+++ b/packages/dap/src/client.ts
@@ -206,9 +206,12 @@ export class DAPClient<
     const time = roundedTime(this.#timePrecisionSeconds, options?.timestamp);
     const metadata = new ReportMetadata(reportId, time, this.#extensions);
 
+    const publicShareLength = Buffer.alloc(4);
+    publicShareLength.writeUInt32BE(publicShare.length);
     const aad = Buffer.concat([
       this.taskId.encode(),
       metadata.encode(),
+      publicShareLength,
       publicShare,
     ]);
 


### PR DESCRIPTION
This adds a length prefix before the public share when building the AAD for an input share, to match Daphne's interpretation. See also https://github.com/divviup/janus/pull/701 and https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/issues/371.