### PR TITLE
Add HEALTHCHECK directive to container

### DIFF
--- a/Dockerfile.interop_client
+++ b/Dockerfile.interop_client
@@ -33,4 +33,5 @@ RUN npm set progress=false && npm ci && npm cache clean --force
 # This copy will include all /dist/ subdirectories, produced by the builder.
 COPY --from=builder /opt/divviup-ts/packages/ /opt/divviup-ts/packages/
 
+HEALTHCHECK CMD ["/bin/sh", "-c", "netstat -tl | grep -q http-alt"]
 CMD ["/bin/sh", "-c", "npx interop-test-client >/logs/stdout.log 2>/logs/stderr.log"]


### PR DESCRIPTION
This adds a `HEALTHCHECK` directive to the interop test Dockerfile. The health check command uses busybox to check if the Node process is listening for TCP connections yet. I plan to make use of this with [`testcontainers::core::WaitFor::Healtcheck`](https://docs.rs/testcontainers/latest/testcontainers/core/enum.WaitFor.html#variant.Healthcheck).