### PR TITLE
update test vdaf to align with test vdaf in poc

### DIFF
--- a/packages/vdaf/src/index.spec.ts
+++ b/packages/vdaf/src/index.spec.ts
@@ -8,7 +8,7 @@ type PrepareState = {
 type AggregationParameter = null;
 type AggregatorShare = Buffer;
 type OutputShare = bigint[];
-type AggregationResult = number[];
+type AggregationResult = number;
 type Measurement = number;
 type TestVdaf = Vdaf<
   Measurement,
@@ -104,16 +104,14 @@ export class VdafTest implements TestVdaf {
     _aggParam: AggregationParameter,
     aggShares: Buffer[]
   ): AggregationResult {
-    return [
-      Number(
-        this.field.sum(aggShares, (aggShare) => this.field.decode(aggShare)[0])
-      ),
-    ];
+    return Number(
+      this.field.sum(aggShares, (aggShare) => this.field.decode(aggShare)[0])
+    );
   }
 }
 
 describe("test vdaf", () => {
   it("behaves as expected", async () => {
-    await testVdaf(new VdafTest(), null, [1, 2, 3, 4], [10]);
+    await testVdaf(new VdafTest(), null, [1, 2, 3, 4], 10);
   });
 });


### PR DESCRIPTION
reference: [vdaf.sage#L274-L355](https://github.com/cfrg/draft-irtf-cfrg-vdaf/blob/ee2db72/poc/vdaf.sage#L274-L355)

I'm not entirely sure why this changed, but we might as well mirror the changes here