### PR TITLE
DAP-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # [DivviUp](https://divviup.org/) Typescript Client
 
-
 [![Coverage Status](https://coveralls.io/repos/github/divviup/divviup-ts/badge.svg?branch=main)](https://coveralls.io/github/divviup/divviup-ts?branch=main)
 [![CI](https://github.com/divviup/divviup-ts/actions/workflows/ci.yaml/badge.svg)](https://github.com/divviup/divviup-ts/actions/workflows/ci.yaml)
 
 [docs for main](https://divviup.github.io/divviup-ts/)
 
+## Protocol Versions
+
+This repository is current to [version DAP-03](https://www.ietf.org/archive/id/draft-ietf-ppm-dap-03.html) and [version VDAF-03](https://www.ietf.org/archive/id/draft-irtf-cfrg-vdaf-03.html)
+
+## Usage
+
 ```typescript
-import DAPClient from "dap";
+import DAPClient from "@divviup/dap";
 
 const client = new DAPClient({
   type: "sum",

--- a/packages/dap/src/aggregator.spec.ts
+++ b/packages/dap/src/aggregator.spec.ts
@@ -1,0 +1,93 @@
+import { Aggregator } from "./aggregator";
+import assert from "assert";
+import { Role } from "./constants";
+import { HpkeConfig, HpkeConfigList } from "./hpkeConfig";
+import { Aead, Kdf, Kem, Keypair } from "hpke";
+import {
+  InputShareAad,
+  InputShareInfo,
+  PlaintextInputShare,
+  ReportMetadata,
+} from "./report";
+import { TaskId } from "./taskId";
+import { ReportId } from "./reportId";
+
+describe("DAP Aggregator", () => {
+  it("should append a trailing slash on construction from a string", () => {
+    const aggregator = new Aggregator(
+      "http://example.com/aggregator",
+      Role.Leader
+    );
+
+    assert.equal(aggregator.url.toString(), "http://example.com/aggregator/");
+  });
+
+  it("should append a trailing slash on construction from a URL", () => {
+    const aggregator = new Aggregator(
+      new URL("http://example.com/aggregator"),
+      Role.Leader
+    );
+
+    assert.equal(aggregator.url.toString(), "http://example.com/aggregator/");
+  });
+
+  it("has a convenience method to build helper aggregator", () => {
+    assert.deepEqual(
+      Aggregator.helper("http://example.com"),
+      new Aggregator("http://example.com", Role.Helper)
+    );
+  });
+
+  it("has a convenience method to build leader aggregator", () => {
+    assert.deepEqual(
+      Aggregator.leader("http://example.com"),
+      new Aggregator("http://example.com", Role.Leader)
+    );
+  });
+
+  it("performs a hpke seal with the first valid hpke config", () => {
+    const aggregator = Aggregator.leader("https://example.com");
+    const kem = Kem.DhP256HkdfSha256;
+    const { public_key, private_key } = new Keypair(kem);
+    const hpkeConfig = new HpkeConfig(
+      1,
+      kem,
+      Kdf.Sha256,
+      Aead.AesGcm128,
+      Buffer.from(public_key)
+    );
+
+    aggregator.hpkeConfigList = new HpkeConfigList([hpkeConfig]);
+    const inputShare = new PlaintextInputShare([], Buffer.from("payload"));
+    const aad = new InputShareAad(
+      TaskId.random(),
+      new ReportMetadata(ReportId.random(), Date.now() / 1000),
+      Buffer.alloc(0)
+    );
+    const cipherText = aggregator.seal(inputShare, aad);
+
+    const open = hpkeConfig
+      .config()
+      .base_mode_open(
+        private_key,
+        cipherText.encapsulatedContext,
+        new InputShareInfo(Role.Leader).encode(),
+        cipherText.payload,
+        aad.encode()
+      );
+
+    assert.deepEqual(Buffer.from(open), inputShare.encode());
+  });
+
+  it("throws when hpke seal is called without a hpke config list", () => {
+    const aggregator = Aggregator.leader("https://example.com");
+    const inputShare = new PlaintextInputShare([], Buffer.from("payload"));
+    const aad = new InputShareAad(
+      TaskId.random(),
+      new ReportMetadata(ReportId.random(), Date.now() / 1000),
+      Buffer.alloc(0)
+    );
+
+    assert.throws(() => aggregator.seal(inputShare, aad));
+  });
+});

--- a/packages/dap/src/aggregator.ts
+++ b/packages/dap/src/aggregator.ts
@@ -1,0 +1,41 @@
+import { Role } from "./constants";
+import { InputShareAad, InputShareInfo, PlaintextInputShare } from "./report";
+import { HpkeCiphertext } from "./ciphertext";
+import { HpkeConfigList } from "./hpkeConfig";
+
+export class Aggregator {
+  public url: URL;
+  constructor(
+    url: URL | string,
+    public role: Role,
+    public hpkeConfigList?: HpkeConfigList
+  ) {
+    this.url = new URL(url);
+    if (!this.url.pathname.endsWith("/")) {
+      this.url.pathname += "/";
+    }
+  }
+
+  static helper(url: string | URL): Aggregator {
+    return new Aggregator(url, Role.Helper);
+  }
+
+  static leader(url: string | URL): Aggregator {
+    return new Aggregator(url, Role.Leader);
+  }
+
+  seal(inputShare: PlaintextInputShare, aad: InputShareAad): HpkeCiphertext {
+    if (!this.hpkeConfigList) {
+      throw new Error(
+        "Attempted to call Aggregator#seal before fetching a hpkeConfigList."
+      );
+    }
+    return this.hpkeConfigList
+      .selectConfig()
+      .seal(
+        new InputShareInfo(this.role).encode(),
+        inputShare.encode(),
+        aad.encode()
+      );
+  }
+}

--- a/packages/dap/src/constants.ts
+++ b/packages/dap/src/constants.ts
@@ -1,0 +1,22 @@
+export const ROUTES = Object.freeze({
+  keyConfig: "hpke_config",
+  upload: "upload",
+});
+
+/**
+   The protocol version for this DAP implementation. Usually of the
+   form `dap-{nn}`.
+*/
+export const DAP_VERSION = Object.freeze("dap-03");
+
+export const CONTENT_TYPES = Object.freeze({
+  REPORT: "application/dap-report",
+  HPKE_CONFIG_LIST: "application/dap-hpke-config-list",
+});
+
+export enum Role {
+  Collector = 0,
+  Client = 1,
+  Leader = 2,
+  Helper = 3,
+}

--- a/packages/dap/src/encoding.spec.ts
+++ b/packages/dap/src/encoding.spec.ts
@@ -1,0 +1,117 @@
+import assert from "assert";
+import { Buffer } from "buffer";
+import { arr } from "@divviup/common";
+import {
+  Encodable,
+  encodeArray16,
+  encodeOpaque16,
+  Parser,
+  ParseSource,
+} from "./encoding";
+
+class Uint16 implements Encodable {
+  constructor(public n: number) {}
+  encode(): Buffer {
+    const buffer = Buffer.alloc(2);
+    buffer.writeUInt16BE(this.n, 0);
+    return buffer;
+  }
+
+  static parse(source: ParseSource): Uint16 {
+    return new Uint16(Parser.from(source).uint16());
+  }
+}
+
+class TestEncodable implements Encodable {
+  constructor(public array16: Uint16[], public opaque16: Buffer) {}
+  encode(): Buffer {
+    return Buffer.concat([
+      encodeArray16(this.array16),
+      encodeOpaque16(this.opaque16),
+    ]);
+  }
+
+  static parse(source: ParseSource): TestEncodable {
+    const parser = Parser.from(source);
+    return new TestEncodable(parser.array16(Uint16), parser.opaque16());
+  }
+}
+
+context("encoding", () => {
+  context("encodeArray16", () => {
+    it("correctly encodes a two byte length description and then the full array", () => {
+      assert.deepEqual(
+        encodeArray16([new Uint16(65535), new Uint16(255)]),
+        Buffer.from([0, 4, 255, 255, 0, 255])
+      );
+    });
+
+    it("throws when the total length of the encoded array is longer than two bytes", () => {
+      const array = arr(Math.floor(65535 / 2), (_) => new Uint16(0));
+      assert.doesNotThrow(() => encodeArray16(array));
+
+      array.push(new Uint16(0));
+      assert.throws(() => encodeArray16(array));
+    });
+  });
+});
+
+context("decoding", () => {
+  it("does not make a new parser if Parser.from is called with a Parser", () => {
+    const parser = Parser.from(Buffer.from("hello"));
+    parser.index = 5;
+    assert.deepStrictEqual(Parser.from(parser), parser);
+    assert.equal(Parser.from(parser).index, 5);
+  });
+
+  context("array16", () => {
+    it("correctly decodes", () => {
+      assert.deepEqual(
+        Parser.from(Buffer.from([0, 4, 255, 255, 0, 255])).array16(Uint16),
+        [new Uint16(65535), new Uint16(255)]
+      );
+    });
+
+    it("throws if the content is too short", () => {
+      const parser = Parser.from(Buffer.from([0, 4, 255, 255, 0]));
+      assert.throws(() => parser.array16(Uint16));
+    });
+
+    it("throws if the Parseable type reads too far", () => {
+      const parser = Parser.from(Buffer.from([0, 3, 255, 255, 0, 0]));
+      assert.throws(
+        () => parser.array16(Uint16),
+        (e: Error) => e.message === "expected to read exactly 3 but read 1 over"
+      );
+    });
+  });
+});
+
+context("TestEncodable", () => {
+  it("can round trip a single parseable encodable", () => {
+    const testEncodable = new TestEncodable(
+      [5, 10, 15, 20].map((n) => new Uint16(n)),
+      Buffer.from("opaque")
+    );
+    const encoded = testEncodable.encode();
+    assert.deepEqual(TestEncodable.parse(encoded), testEncodable);
+  });
+
+  it("can round trip an array16 of parseable encodables", () => {
+    const testEncodables = [
+      new TestEncodable(
+        [5, 10, 15, 20].map((n) => new Uint16(n)),
+        Buffer.from("opaque")
+      ),
+      new TestEncodable(
+        [1, 2, 3].map((n) => new Uint16(n)),
+        Buffer.from("also opaque")
+      ),
+    ];
+    const encoded = encodeArray16(testEncodables);
+    assert.deepEqual(
+      Parser.from(encoded).array16(TestEncodable),
+      testEncodables
+    );
+  });
+});

--- a/packages/dap/src/report.spec.ts
+++ b/packages/dap/src/report.spec.ts
@@ -72,7 +72,7 @@ describe("DAP PlaintextInputShare", () => {
       plaintextInputShare.encode(),
       Buffer.from([
         ...[0, 0], //array16 extensions
-        ...[0, 0, 0, payload.length], // opaque32 payload length length
+        ...[0, 0, 0, payload.length], // opaque32 payload length
         ...payload,
       ])
     );

--- a/packages/dap/src/report.spec.ts
+++ b/packages/dap/src/report.spec.ts
@@ -1,8 +1,15 @@
-import { Report, ReportMetadata } from "./report";
+import {
+  InputShareAad,
+  InputShareInfo,
+  PlaintextInputShare,
+  Report,
+  ReportMetadata,
+} from "./report";
 import { TaskId } from "./taskId";
 import { ReportId } from "./reportId";
 import { HpkeCiphertext } from "./ciphertext";
 import assert from "assert";
+import { Role } from "./constants";
 
 describe("DAP Report", () => {
   it("encodes as expected", () => {
@@ -21,7 +28,7 @@ describe("DAP Report", () => {
       Buffer.alloc(2, 2)
     );
 
-    const reportMetadata = new ReportMetadata(reportId, 0, []);
+    const reportMetadata = new ReportMetadata(reportId, 0);
     const report = new Report(taskId, reportMetadata, Buffer.alloc(0), [
       ciphertext1,
       ciphertext2,
@@ -45,15 +52,61 @@ describe("DAP ReportMetadata", () => {
   it("encodes as expected", () => {
     const reportId = ReportId.random();
     const time = 1_000_000_000;
-    const reportMetadata = new ReportMetadata(reportId, time, []);
+    const reportMetadata = new ReportMetadata(reportId, time);
 
     assert.deepEqual(
       reportMetadata.encode(),
       Buffer.from([
         ...reportId.encode(), // tested in reportId.spec
         ...[0, 0, 0, 0, 0x3b, 0x9a, 0xca, 0x00],
-        ...[0, 0], // there are no extensions
       ])
+    );
+  });
+});
+
+describe("DAP PlaintextInputShare", () => {
+  it("encodes as expected", () => {
+    const payload = Buffer.from("payload");
+    const plaintextInputShare = new PlaintextInputShare([], payload);
+    assert.deepEqual(
+      plaintextInputShare.encode(),
+      Buffer.from([
+        ...[0, 0], //array16 extensions
+        ...[0, 0, 0, payload.length], // opaque32 payload length length
+        ...payload,
+      ])
+    );
+  });
+});
+
+describe("DAP InputShareAad", () => {
+  it("encodes as expected", () => {
+    const taskId = TaskId.random();
+    const reportId = ReportId.random();
+    const metadata = new ReportMetadata(reportId, 1);
+    const publicShare = Buffer.from("public share");
+    const aad = new InputShareAad(taskId, metadata, publicShare);
+    assert.deepEqual(
+      aad.encode(),
+      Buffer.from([
+        ...taskId.encode(),
+        ...metadata.encode(),
+        ...[0, 0, 0, publicShare.length], ///opaque32 public share
+        ...publicShare,
+      ])
+    );
+  });
+});
+
+describe("DAP InputShareInfo", () => {
+  it("encodes as expected", () => {
+    assert.deepEqual(
+      new InputShareInfo(Role.Helper).encode(),
+      Buffer.from([...Buffer.from("dap-03 input share"), 1, 3])
+    );
+    assert.deepEqual(
+      new InputShareInfo(Role.Leader).encode(),
+      Buffer.from([...Buffer.from("dap-03 input share"), 1, 2])
     );
   });
 });

--- a/packages/dap/src/report.ts
+++ b/packages/dap/src/report.ts
@@ -2,27 +2,22 @@ import { Buffer } from "buffer";
 import { TaskId } from "./taskId";
 import {
   Encodable,
-  encodeArray16,
   encodeArray32,
+  encodeArray16,
   encodeOpaque32,
 } from "./encoding";
 import { ReportId } from "./reportId";
-import { Extension } from "./extension";
 import { HpkeCiphertext } from "./ciphertext";
+import { DAP_VERSION, Role } from "./constants";
+import { Extension } from "./extension";
 
 export class ReportMetadata implements Encodable {
-  constructor(
-    public reportID: ReportId,
-    public time: number,
-    public extensions: Extension[]
-  ) {}
+  constructor(public reportID: ReportId, public time: number) {}
 
   encode(): Buffer {
-    const encodedExtensions = encodeArray16(this.extensions);
-    const buffer = Buffer.alloc(24 + encodedExtensions.length);
+    const buffer = Buffer.alloc(24);
     this.reportID.encode().copy(buffer, 0);
     buffer.writeUInt32BE(this.time, 16 + 4);
-    encodedExtensions.copy(buffer, 24);
     return buffer;
   }
 }
@@ -41,6 +36,46 @@ export class Report implements Encodable {
       this.metadata.encode(),
       encodeOpaque32(this.publicShare),
       encodeArray32(this.encryptedInputShares),
+    ]);
+  }
+}
+
+export class PlaintextInputShare implements Encodable {
+  constructor(public extensions: Extension[], public payload: Buffer) {}
+
+  encode(): Buffer {
+    return Buffer.concat([
+      encodeArray16(this.extensions),
+      encodeOpaque32(this.payload),
+    ]);
+  }
+}
+
+export class InputShareAad implements Encodable {
+  constructor(
+    public taskId: TaskId,
+    public metadata: ReportMetadata,
+    public publicShare: Buffer
+  ) {}
+
+  encode(): Buffer {
+    return Buffer.concat([
+      this.taskId.encode(),
+      this.metadata.encode(),
+      encodeOpaque32(this.publicShare),
+    ]);
+  }
+}
+
+/** A Buffer that will always equal `${DAP_VERSION} input share` */
+const INPUT_SHARE_ASCII = Buffer.from(`${DAP_VERSION} input share`, "ascii");
+
+export class InputShareInfo implements Encodable {
+  constructor(public serverRole: Role) {}
+  encode(): Buffer {
+    return Buffer.concat([
+      INPUT_SHARE_ASCII,
+      Buffer.from([1, this.serverRole]),
     ]);
   }
 }


### PR DESCRIPTION
Changes:
* remove extensions from report metadata
* add PlaintextInputShare to combine payload and extensions
* add InputShareAad instead of anonymous Buffer.concat in client
* add InputShareInfo instead of anonymous Buffer.concat in client
* add HpkeConfigList and parseArray16 to support it, update mime type
* move constants from client to a constants.ts file
* make Aggregator a class instead of an interface and move some logic previously in the client to the Aggregator, including hpke sealing logic
* update the version tag to DAP-03
* include explicit DAP and VDAF version support in the README (closes #10)