### PR TITLE
Update docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,9 @@ jobs:
       run: |-
         docker build \
           -t us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:${{ steps.get_commit.outputs.COMMIT }} \
-          -t us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:dap-draft-02 \
+          -t us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:dap-draft-03 \
           -t us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:${{ steps.get_commit.outputs.COMMIT }} \
-          -t us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02 \
+          -t us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-03 \
           -f Dockerfile.interop_client \
           .
     - id: "gcp-auth-private"
@@ -61,7 +61,7 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       run: |-
         docker push us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:${{ steps.get_commit.outputs.COMMIT }} && \
-          docker push us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:dap-draft-02
+          docker push us-west2-docker.pkg.dev/janus-artifacts/divviup-ts/divviup_ts_interop_client:dap-draft-03
     - name: Docker Login (public)
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       uses: "docker/login-action@v2"
@@ -73,4 +73,4 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       run: |-
         docker push us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:${{ steps.get_commit.outputs.COMMIT }} && \
-          docker push us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-02
+          docker push us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:dap-draft-03


### PR DESCRIPTION
This bumps the Docker container tag to reflect that we now implement DAP-03. This is a follow-up to #175.

Once this lands, I'll go into the registries and manually rewind the `dap-draft-02` tag to the last image that actually supported DAP-02, which is also tagged as `us-west2-docker.pkg.dev/divviup-artifacts-public/divviup-ts/divviup_ts_interop_client:4bc5b78`, with digest `sha256:1fdcbea395465eeac1cb49f8bb65f419d9b5e147a993f8cf912310a8ea0b62e6`.