### PR TITLE
Add another clean-install to last Dockerfile stage

### DIFF
--- a/Dockerfile.interop_client
+++ b/Dockerfile.interop_client
@@ -13,7 +13,6 @@ COPY tsconfig.json .
 COPY lerna.json .
 COPY nx.json .
 COPY packages/ packages/
-# Re-run clean-install to set up bin symlinks.
 RUN npm ci
 RUN npx lerna run build --scope interop-test-client --no-progress && rm -rf node_modules/.cache/nx
 
@@ -30,8 +29,8 @@ COPY --from=builder /opt/divviup-ts/packages/interop-test-client/bin/ /opt/divvi
 COPY --from=builder /opt/divviup-ts/package.json /opt/divviup-ts/package.json
 COPY --from=builder /opt/divviup-ts/package-lock.json /opt/divviup-ts/package-lock.json
 RUN npm set progress=false && npm ci && npm cache clean --force
-# This copy will include all /dist/ subdirectories, produced by the builder.
 COPY --from=builder /opt/divviup-ts/packages/ /opt/divviup-ts/packages/
+RUN npm ci && npm cache clean --force
 
 HEALTHCHECK CMD ["/bin/sh", "-c", "netstat -tl | grep -q http-alt"]
 CMD ["/bin/sh", "-c", "npx interop-test-client >/logs/stdout.log 2>/logs/stderr.log"]


### PR DESCRIPTION
I tried building and running the interop test Docker container, and it failed because there was no `node_modules/.bin` directory. Presumably this happened due to a change in one of the build tools we use. This PR fixes the issue by adding another `npm clean-install` invocation after all files have been copied into the final stage.