### PR TITLE
Fix CODEOWNERS format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @divviup/committers
-* @jbr
+* @divviup/committers @jbr


### PR DESCRIPTION
`@divviup/committers` wasn't being recognized as a code owner because I put the two entries on separate lines.