### PR TITLE
Janus interop test, DAP draft-03

### DIFF
--- a/packages/interop-test-client/bin/interop-test-client
+++ b/packages/interop-test-client/bin/interop-test-client
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require("../dist/index.js").interopTestClient();
+require("../dist/index.js").run();

--- a/packages/interop-test-client/package.json
+++ b/packages/interop-test-client/package.json
@@ -15,13 +15,18 @@
   ],
   "scripts": {
     "clean": "rm -rf dist/*",
-    "build": "parcel build"
+    "build": "parcel build",
+    "test": "ts-mocha \"src/**/*.spec.ts\" -p ./tsconfig.json",
+    "lint": "eslint src --ext .ts && prettier -c src",
+    "format": "prettier -w src"
   },
   "dependencies": {
     "@divviup/dap": "^0.1.0",
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.16"
+    "@divviup/common": "^0.1.0",
+    "@types/express": "^4.17.16",
+    "@types/mocha": "^10.0.1"
   }
 }

--- a/packages/interop-test-client/src/index.spec.ts
+++ b/packages/interop-test-client/src/index.spec.ts
@@ -1,7 +1,8 @@
 import { app } from ".";
-import { arr } from "@divviup/common";
+import { arr, randomBytes } from "@divviup/common";
 import { AddressInfo } from "node:net";
 import { spawnSync, SpawnSyncReturns } from "node:child_process";
+import { Server } from "node:http";
 
 const JANUS_INTEROP_AGGREGATOR_IMAGE =
   "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_aggregator:0.3.1@sha256:badba0c9ecbe291368df507f42997ba0224774447cb02504fa9a406c4e49a968";
@@ -28,11 +29,11 @@ function spawnSyncAndThrow(
   if (result.error) {
     throw result.error;
   } else if (result.status !== null && result.status !== 0) {
-    throw Error(
+    throw new Error(
       `${command} failed with status code ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
     );
   } else if (result.signal !== null) {
-    throw Error(`${command} was killed with signal ${result.signal}`);
+    throw new Error(`${command} was killed with signal ${result.signal}`);
   }
   return result;
 }
@@ -73,7 +74,7 @@ class Container {
     const result = spawnSyncAndThrow("docker", ["port", name, "8080"]);
     const match = /^0\.0\.0\.0:([0-9]+)$/m.exec(result.stdout);
     if (!match) {
-      throw Error(
+      throw new Error(
         `docker port output could not be parsed, was ${result.stdout}`
       );
     }
@@ -83,18 +84,286 @@ class Container {
   delete() {
     spawnSync("docker", ["rm", "--force", this.name]);
   }
+
+  async waitForReady() {
+    await waitForReady(this.port);
+  }
+
+  /** Send a interoperation test API request, and return the response. */
+  async sendRequest(
+    apiEndpoint: string,
+    requestBody: object
+  ): Promise<object & Record<"status", unknown>> {
+    const response = await fetch(
+      `http://127.0.0.1:${this.port}/internal/test/${apiEndpoint}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      }
+    );
+    return await checkResponseError(response);
+  }
+}
+
+/** Check the status field in a response, throw an error if it wasn't successful, and return the
+ * response body otherwise. */
+async function checkResponseError(
+  response: Response
+): Promise<object & Record<"status", unknown>> {
+  if (response.status !== 200) {
+    const body = await response.text();
+    throw new Error(
+      `Test API returned status code ${response.status}, body: ${body}`
+    );
+  }
+  const rawBody: unknown = await response.json();
+
+  if (
+    typeof rawBody !== "object" ||
+    Array.isArray(rawBody) ||
+    rawBody === null
+  ) {
+    throw new Error("Response JSON body is not an object");
+  }
+
+  if (!("status" in rawBody)) {
+    throw new Error("`status` is missing");
+  }
+  if (
+    rawBody.status !== "success" &&
+    rawBody.status !== "complete" &&
+    rawBody.status !== "in progress"
+  ) {
+    const body = rawBody as {
+      status: unknown;
+      error?: unknown;
+    };
+    throw new Error(`Request failed: ${JSON.stringify(body)}`);
+  }
+  return rawBody;
+}
+
+class Aggregator extends Container {
+  async endpointForTask(taskId: EncodedBlob, role: string): Promise<URL> {
+    const rawBody = await this.sendRequest("endpoint_for_task", {
+      task_id: taskId.toString(),
+      role: role,
+      hostname: this.name,
+    });
+
+    if (!("endpoint" in rawBody)) {
+      throw new Error(`\`endpoint\` is missing: ${JSON.stringify(rawBody)}`);
+    }
+
+    const body = rawBody as { endpoint: unknown };
+    if (typeof body.endpoint !== "string") {
+      throw new Error("`endpoint` is not a string");
+    }
+    return new URL(body.endpoint, `http://${this.name}:8080/`);
+  }
+
+  /** Send an /internal/test/add_task request. */
+  async addTask(
+    taskId: EncodedBlob,
+    role: string,
+    leaderEndpoint: URL,
+    helperEndpoint: URL,
+    aggregatorAuthToken: string,
+    collectorAuthToken: string | null,
+    vdafVerifyKey: EncodedBlob,
+    maxBatchQueryCount: number,
+    minBatchSize: number,
+    timePrecisionSeconds: number,
+    collectorHpkeConfig: string,
+    taskExpiration: number
+  ): Promise<void> {
+    const requestBody: Record<string, string | number | object> = {
+      task_id: taskId.toString(),
+      leader: leaderEndpoint.toString(),
+      helper: helperEndpoint.toString(),
+      vdaf: {
+        type: "Prio3Aes128Count",
+      },
+      leader_authentication_token: aggregatorAuthToken,
+      role: role,
+      vdaf_verify_key: vdafVerifyKey.toString(),
+      max_batch_query_count: maxBatchQueryCount,
+      query_type: 1,
+      min_batch_size: minBatchSize,
+      time_precision: timePrecisionSeconds,
+      collector_hpke_config: collectorHpkeConfig,
+      task_expiration: taskExpiration,
+    };
+    if (collectorAuthToken !== null) {
+      requestBody["collector_authentication_token"] = collectorAuthToken;
+    }
+    await this.sendRequest("add_task", requestBody);
+  }
+}
+
+class Collector extends Container {
+  /** Send an /internal/test/add_task request, and return the encoded collector HPKE configuration. */
+  async addTask(
+    taskId: EncodedBlob,
+    leaderEndpoint: URL,
+    collectorAuthToken: string
+  ): Promise<string> {
+    const rawBody = await this.sendRequest("add_task", {
+      task_id: taskId.toString(),
+      leader: leaderEndpoint.toString(),
+      vdaf: {
+        type: "Prio3Aes128Count",
+      },
+      collector_authentication_token: collectorAuthToken,
+      query_type: 1,
+    });
+
+    if (!("collector_hpke_config" in rawBody)) {
+      throw new Error("`collector_hpke_config` is missing");
+    }
+
+    const body = rawBody as { collector_hpke_config: unknown };
+    if (typeof body.collector_hpke_config !== "string") {
+      throw new Error("`collector_hpke_config` is not a string");
+    }
+    return body.collector_hpke_config;
+  }
+
+  /** Send an /internal/test/collect_start request, and return the handle for the request. */
+  async collectStart(
+    taskId: EncodedBlob,
+    batchIntervalStart: number,
+    batchIntervalDuration: number
+  ): Promise<string> {
+    const rawBody = await this.sendRequest("collect_start", {
+      task_id: taskId.toString(),
+      agg_param: "",
+      query: {
+        type: 1,
+        batch_interval_start: batchIntervalStart,
+        batch_interval_duration: batchIntervalDuration,
+      },
+    });
+
+    if (!("handle" in rawBody)) {
+      throw new Error("`handle` is missing");
+    }
+
+    const body = rawBody as { handle: unknown };
+    if (typeof body.handle !== "string") {
+      throw new Error("`handle` is not a string");
+    }
+    return body.handle;
+  }
+
+  /**
+  Send an /internal/test/collect_poll request, and return the collection's results if they are
+  ready, or null if the collection is still being processed.
+  */
+  async collectPoll(handle: string): Promise<Collection | null> {
+    const rawBody = await this.sendRequest("collect_poll", {
+      handle: handle,
+    });
+
+    if (rawBody.status === "in progress") {
+      return null;
+    }
+
+    if (!("result" in rawBody)) {
+      throw new Error("`result` is missing");
+    }
+    if (!("report_count" in rawBody)) {
+      throw new Error("`report_count` is missing");
+    }
+
+    const body = rawBody as { result: unknown; report_count: unknown };
+    if (typeof body.result !== "string" && !Array.isArray(body.result)) {
+      throw new Error("`result` is not a string or array");
+    }
+    if (typeof body.report_count !== "number") {
+      throw new Error("`report_count` is not a number");
+    }
+    return {
+      result: body.result,
+      reportCount: body.report_count,
+    };
+  }
+}
+
+type Collection = {
+  result: string | Array<string>;
+  reportCount: number;
+};
+
+async function upload(
+  clientPort: number,
+  taskId: EncodedBlob,
+  leaderEndpoint: URL,
+  helperEndpoint: URL,
+  timePrecision: number
+): Promise<void> {
+  const response = await fetch(
+    `http://127.0.0.1:${clientPort}/internal/test/upload`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        task_id: taskId.toString(),
+        leader: leaderEndpoint.toString(),
+        helper: helperEndpoint.toString(),
+        vdaf: {
+          type: "Prio3Aes128Count",
+        },
+        measurement: "1",
+        time_precision: timePrecision,
+      }),
+    }
+  );
+  await checkResponseError(response);
+}
+
+class EncodedBlob {
+  buffer: Buffer;
+
+  constructor(input: Buffer) {
+    this.buffer = input;
+  }
+
+  static random(length: number): EncodedBlob {
+    return new EncodedBlob(Buffer.from(randomBytes(length)));
+  }
+
+  toString(): string {
+    return this.buffer
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+  }
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/// Polls and waits for an interop API server listening on a given port to be ready.
+/** Polls and waits for an interop API server listening on a given port to be ready. */
 async function waitForReady(port: number) {
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 15; i++) {
     try {
       const response = await fetch(
-        `http://127.0.0.1:${port}/internal/test/ready`
+        `http://127.0.0.1:${port}/internal/test/ready`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }
       );
       if (response.status === 200) {
         return;
@@ -104,39 +373,139 @@ async function waitForReady(port: number) {
       await sleep(1000);
     }
   }
+  throw new Error("Timed out waiting for server to be ready");
 }
 
 async function runIntegrationTest(
   clientPort: number,
   clientOnLocalhost: boolean,
-  leader: Container,
-  helper: Container,
-  collector: Container
+  leader: Aggregator,
+  helper: Aggregator,
+  collector: Collector
 ) {
+  const reportCount = 10;
+
+  const maxBatchQueryCount = 1;
+  const minBatchSize = 10;
+  const timePrecision = 300;
+  const taskExpiration = 9000000000;
+
   await waitForReady(clientPort);
-  await waitForReady(leader.port);
-  await waitForReady(helper.port);
-  await waitForReady(collector.port);
-  // TODO: task setup, upload, aggregate, and collect
+  await leader.waitForReady();
+  await helper.waitForReady();
+  await collector.waitForReady();
+
+  const taskId = EncodedBlob.random(32);
+  const aggregatorAuthToken = `aggregator-${randomSuffix()}`;
+  const collectorAuthToken = `collector-${randomSuffix()}`;
+  const vdafVerifyKey = EncodedBlob.random(16);
+
+  const leaderEndpoint = await leader.endpointForTask(taskId, "leader");
+  const helperEndpoint = await helper.endpointForTask(taskId, "helper");
+
+  const collectorHpkeConfig = await collector.addTask(
+    taskId,
+    leaderEndpoint,
+    collectorAuthToken
+  );
+  await leader.addTask(
+    taskId,
+    "leader",
+    leaderEndpoint,
+    helperEndpoint,
+    aggregatorAuthToken,
+    collectorAuthToken,
+    vdafVerifyKey,
+    maxBatchQueryCount,
+    minBatchSize,
+    timePrecision,
+    collectorHpkeConfig,
+    taskExpiration
+  );
+  await helper.addTask(
+    taskId,
+    "helper",
+    leaderEndpoint,
+    helperEndpoint,
+    aggregatorAuthToken,
+    null,
+    vdafVerifyKey,
+    maxBatchQueryCount,
+    minBatchSize,
+    timePrecision,
+    collectorHpkeConfig,
+    taskExpiration
+  );
+
+  let leaderEndpointForClient: URL;
+  let helperEndpointForClient: URL;
+  if (clientOnLocalhost) {
+    leaderEndpointForClient = new URL(
+      leaderEndpoint
+        .toString()
+        .replace(`${leader.name}:8080`, `127.0.0.1:${leader.port}`)
+    );
+    helperEndpointForClient = new URL(
+      helperEndpoint
+        .toString()
+        .replace(`${helper.name}:8080`, `127.0.0.1:${helper.port}`)
+    );
+  } else {
+    leaderEndpointForClient = leaderEndpoint;
+    helperEndpointForClient = helperEndpoint;
+  }
+
+  const start = new Date();
+  for (let i = 0; i < reportCount; i++) {
+    await upload(
+      clientPort,
+      taskId,
+      leaderEndpointForClient,
+      helperEndpointForClient,
+      timePrecision
+    );
+  }
+
+  const collectHandle = await collector.collectStart(
+    taskId,
+    Math.floor(start.getTime() / 1000 / timePrecision) * timePrecision,
+    timePrecision * 2
+  );
+  for (let i = 0; i < 30; i++) {
+    const collection = await collector.collectPoll(collectHandle);
+    if (collection === null) {
+      await sleep(1000);
+      continue;
+    }
+
+    if (collection.reportCount != reportCount) {
+      throw new Error("Number of reports did not match");
+    }
+    if (parseInt(collection.result as string, 10) != reportCount) {
+      throw new Error("Aggregate result did not match");
+    }
+    return;
+  }
+  throw new Error("Timed out waiting for collection to finish");
 }
 
 async function runIntegrationTestWithHostClient(clientPort: number) {
   const suffix = randomSuffix();
   const network = new Network(`divviup-ts-interop-${suffix}`);
   try {
-    const leader = new Container(
+    const leader = new Aggregator(
       JANUS_INTEROP_AGGREGATOR_IMAGE,
       `leader-${suffix}`,
       network
     );
     try {
-      const helper = new Container(
+      const helper = new Aggregator(
         JANUS_INTEROP_AGGREGATOR_IMAGE,
         `helper-${suffix}`,
         network
       );
       try {
-        const collector = new Container(
+        const collector = new Collector(
           JANUS_INTEROP_COLLECTOR_IMAGE,
           `collector-${suffix}`,
           network
@@ -163,7 +532,11 @@ async function runIntegrationTestWithHostClient(clientPort: number) {
 describe("interoperation test", function () {
   this.timeout(60000);
   it("is compatible with Janus", async () => {
-    const server = app().listen(0);
+    const server: Server = await new Promise((resolve) => {
+      const server: Server = app().listen(0, "127.0.0.1", 511, () =>
+        resolve(server)
+      );
+    });
     try {
       const clientPort = (server.address() as AddressInfo).port;
       await runIntegrationTestWithHostClient(clientPort);

--- a/packages/interop-test-client/src/index.spec.ts
+++ b/packages/interop-test-client/src/index.spec.ts
@@ -1,0 +1,174 @@
+import { app } from ".";
+import { arr } from "@divviup/common";
+import { AddressInfo } from "node:net";
+import { spawnSync, SpawnSyncReturns } from "node:child_process";
+
+const JANUS_INTEROP_AGGREGATOR_IMAGE =
+  "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_aggregator:0.3.1@sha256:badba0c9ecbe291368df507f42997ba0224774447cb02504fa9a406c4e49a968";
+const JANUS_INTEROP_COLLECTOR_IMAGE =
+  "us-west2-docker.pkg.dev/divviup-artifacts-public/janus/janus_interop_collector:0.3.1@sha256:12f7e170481794116a7f337d2b5b1fd6619e0d512573018aa546a0fb84a5f2b6";
+
+const IDENTIFIER_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomSuffix(): string {
+  return arr(
+    10,
+    (_) =>
+      IDENTIFIER_ALPHABET[
+        Math.floor(Math.random() * IDENTIFIER_ALPHABET.length)
+      ]
+  ).join("");
+}
+
+function spawnSyncAndThrow(
+  command: string,
+  args: Array<string>
+): SpawnSyncReturns<string> {
+  const result = spawnSync(command, args, { encoding: "utf-8" });
+  if (result.error) {
+    throw result.error;
+  } else if (result.status !== null && result.status !== 0) {
+    throw Error(
+      `${command} failed with status code ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  } else if (result.signal !== null) {
+    throw Error(`${command} was killed with signal ${result.signal}`);
+  }
+  return result;
+}
+
+class Network {
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+    spawnSyncAndThrow("docker", ["network", "create", "--driver=bridge", name]);
+  }
+
+  tryDisconnect(containerName: string) {
+    // Ignore error status codes, which are expected in the case where no container with this name
+    // exists.
+    spawnSync("docker", ["network", "disconnect", this.name, containerName]);
+  }
+
+  delete() {
+    spawnSyncAndThrow("docker", ["network", "rm", this.name]);
+  }
+}
+
+class Container {
+  port: number;
+  name: string;
+
+  constructor(image: string, name: string, network: Network) {
+    this.name = name;
+    spawnSyncAndThrow("docker", [
+      "run",
+      "--detach",
+      `--name=${name}`,
+      `--network=${network.name}`,
+      `--publish=8080`,
+      image,
+    ]);
+    const result = spawnSyncAndThrow("docker", ["port", name, "8080"]);
+    const match = /^0\.0\.0\.0:([0-9]+)$/m.exec(result.stdout);
+    if (!match) {
+      throw Error(
+        `docker port output could not be parsed, was ${result.stdout}`
+      );
+    }
+    this.port = parseInt(match[1], 10);
+  }
+
+  delete() {
+    spawnSync("docker", ["rm", "--force", this.name]);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/// Polls and waits for an interop API server listening on a given port to be ready.
+async function waitForReady(port: number) {
+  for (let i = 0; i < 5; i++) {
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/internal/test/ready`
+      );
+      if (response.status === 200) {
+        return;
+      }
+      await sleep(1000);
+    } catch {
+      await sleep(1000);
+    }
+  }
+}
+
+async function runIntegrationTest(
+  clientPort: number,
+  clientOnLocalhost: boolean,
+  leader: Container,
+  helper: Container,
+  collector: Container
+) {
+  await waitForReady(clientPort);
+  await waitForReady(leader.port);
+  await waitForReady(helper.port);
+  await waitForReady(collector.port);
+  // TODO: task setup, upload, aggregate, and collect
+}
+
+async function runIntegrationTestWithHostClient(clientPort: number) {
+  const suffix = randomSuffix();
+  const network = new Network(`divviup-ts-interop-${suffix}`);
+  try {
+    const leader = new Container(
+      JANUS_INTEROP_AGGREGATOR_IMAGE,
+      `leader-${suffix}`,
+      network
+    );
+    try {
+      const helper = new Container(
+        JANUS_INTEROP_AGGREGATOR_IMAGE,
+        `helper-${suffix}`,
+        network
+      );
+      try {
+        const collector = new Container(
+          JANUS_INTEROP_COLLECTOR_IMAGE,
+          `collector-${suffix}`,
+          network
+        );
+        try {
+          await runIntegrationTest(clientPort, true, leader, helper, collector);
+        } finally {
+          collector.delete();
+        }
+      } finally {
+        helper.delete();
+      }
+    } finally {
+      leader.delete();
+    }
+  } finally {
+    network.tryDisconnect(`collector-${suffix}`);
+    network.tryDisconnect(`helper-${suffix}`);
+    network.tryDisconnect(`leader-${suffix}`);
+    network.delete();
+  }
+}
+
+describe("interoperation test", function () {
+  this.timeout(60000);
+  it("is compatible with Janus", async () => {
+    const server = app().listen(0);
+    try {
+      const clientPort = (server.address() as AddressInfo).port;
+      await runIntegrationTestWithHostClient(clientPort);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/packages/interop-test-client/src/index.ts
+++ b/packages/interop-test-client/src/index.ts
@@ -3,17 +3,17 @@ import express, { Request, Response } from "express";
 import DAPClient, { ReportOptions } from "@divviup/dap";
 
 interface CountVdafObject {
-  type: "Prio3Aes128Count",
+  type: "Prio3Aes128Count";
 }
 
 interface SumVdafObject {
-  type: "Prio3Aes128Sum",
-  bits: number,
+  type: "Prio3Aes128Sum";
+  bits: number;
 }
 
 interface HistogramVdafObject {
-  type: "Prio3Aes128Histogram",
-  buckets: string[],
+  type: "Prio3Aes128Histogram";
+  buckets: string[];
 }
 
 type VdafObject = CountVdafObject | SumVdafObject | HistogramVdafObject;
@@ -21,17 +21,21 @@ type VdafObject = CountVdafObject | SumVdafObject | HistogramVdafObject;
 type Measurement = number | string | string[];
 
 interface UploadRequest {
-  task_id: string,
-  leader: string,
-  helper: string,
-  vdaf: VdafObject,
-  measurement: Measurement,
-  time?: number,
-  time_precision: number,
+  task_id: string;
+  leader: string;
+  helper: string;
+  vdaf: VdafObject;
+  measurement: Measurement;
+  time?: number;
+  time_precision: number;
 }
 
 function sanitizeRequest(rawBody: unknown): UploadRequest {
-  if (typeof rawBody !== "object" || Array.isArray(rawBody) || rawBody === null) {
+  if (
+    typeof rawBody !== "object" ||
+    Array.isArray(rawBody) ||
+    rawBody === null
+  ) {
     throw new Error("JSON body is not an object");
   }
 
@@ -55,13 +59,13 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
   }
 
   const body = rawBody as {
-    task_id: unknown,
-    leader: unknown,
-    helper: unknown,
-    vdaf: unknown,
-    measurement: unknown,
-    time?: unknown,
-    time_precision: unknown,
+    task_id: unknown;
+    leader: unknown;
+    helper: unknown;
+    vdaf: unknown;
+    measurement: unknown;
+    time?: unknown;
+    time_precision: unknown;
   };
 
   if (typeof body.task_id !== "string") {
@@ -73,10 +77,18 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
   if (typeof body.helper !== "string") {
     throw new Error("Helper endpoint URL is not a string");
   }
-  if (typeof body.vdaf !== "object" || Array.isArray(body.vdaf) || body.vdaf === null) {
+  if (
+    typeof body.vdaf !== "object" ||
+    Array.isArray(body.vdaf) ||
+    body.vdaf === null
+  ) {
     throw new Error("VDAF definition is not an object");
   }
-  if (typeof body.measurement !== "number" && typeof body.measurement !== "string" && !Array.isArray(body.measurement)) {
+  if (
+    typeof body.measurement !== "number" &&
+    typeof body.measurement !== "string" &&
+    !Array.isArray(body.measurement)
+  ) {
     throw new Error("Measurement is not a number, string, or array");
   }
   if (body.time !== undefined && typeof body.time !== "number") {
@@ -91,9 +103,9 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
   }
 
   const vdaf = body.vdaf as {
-    type: unknown,
-    bits?: unknown,
-    buckets?: unknown,
+    type: unknown;
+    bits?: unknown;
+    buckets?: unknown;
   };
 
   if (typeof vdaf.type !== "string") {
@@ -126,10 +138,14 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
         } else if (typeof vdaf.bits == "string") {
           bits = parseInt(vdaf.bits, 10);
           if (isNaN(bits)) {
-            throw new Error("VDAF definition's `bits` parameter is not a valid base 10 integer");
+            throw new Error(
+              "VDAF definition's `bits` parameter is not a valid base 10 integer"
+            );
           }
         } else {
-          throw new Error("VDAF definition's `bits` parameter is not a number or string");
+          throw new Error(
+            "VDAF definition's `bits` parameter is not a number or string"
+          );
         }
         if (typeof body.measurement !== "string") {
           throw new Error("Measurement is not a string");
@@ -148,11 +164,15 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
         throw new Error("VDAF definition is missing buckets");
       }
       if (!Array.isArray(vdaf.buckets)) {
-        throw new Error("VDAF definition's `buckets` parameter is not an array");
+        throw new Error(
+          "VDAF definition's `buckets` parameter is not an array"
+        );
       }
       for (const bucketBoundary of vdaf.buckets) {
         if (typeof bucketBoundary !== "string") {
-          throw new Error("VDAF defeinition's `buckets` parameter is not an array of strings");
+          throw new Error(
+            "VDAF defeinition's `buckets` parameter is not an array of strings"
+          );
         }
       }
       if (typeof body.measurement !== "string") {
@@ -162,7 +182,7 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
       vdafObject = {
         type: vdaf.type,
         buckets: vdaf.buckets as string[],
-      }
+      };
       measurement = body.measurement;
       break;
 
@@ -178,7 +198,7 @@ function sanitizeRequest(rawBody: unknown): UploadRequest {
     measurement: measurement,
     time: body.time,
     time_precision: body.time_precision,
-  }
+  };
 }
 
 function assertUnreachable(_: never): never {
@@ -191,7 +211,7 @@ async function uploadHandler(req: Request, res: Response): Promise<void> {
     body = sanitizeRequest(req.body);
   } catch (error) {
     console.error(error);
-    res.status(400).send({"status": "error", "error": String(error)});
+    res.status(400).send({ status: "error", error: String(error) });
     return;
   }
 
@@ -238,16 +258,16 @@ async function uploadHandler(req: Request, res: Response): Promise<void> {
         assertUnreachable(body.vdaf);
     }
     console.log("Successful upload");
-    res.send({"status": "success"});
+    res.send({ status: "success" });
   } catch (error) {
     console.log("Failed upload", error);
     // Send this with status 200 OK, as the error came from the DAP level,
     // not the test API level.
-    res.send({"status": "error", "error": String(error)});
+    res.send({ status: "error", error: String(error) });
   }
 }
 
-export function interopTestClient() {
+export function app(): express.Express {
   const app = express();
   app.use(express.json());
 
@@ -258,7 +278,10 @@ export function interopTestClient() {
   app.post("/internal/test/upload", (req, res, next) => {
     uploadHandler(req, res).catch(next);
   });
+  return app;
+}
 
-  console.debug("Starting server on port 8080")
-  app.listen(8080);
+export function run() {
+  console.debug("Starting server on port 8080");
+  app().listen(8080);
 }

--- a/packages/interop-test-client/src/index.ts
+++ b/packages/interop-test-client/src/index.ts
@@ -272,6 +272,7 @@ export function app(): express.Express {
   app.use(express.json());
 
   app.post("/internal/test/ready", (_req, res) => {
+    console.log("Ready request");
     res.send({});
   });
 


### PR DESCRIPTION
This adds an interop test against Janus. It pulls the relevant Janus images, starts them up, alongside an in-process divviup-ts client, and runs aggregations. I'm filing this against the release/dap-draft-03 branch first, because both draft-04 implementations are not ready yet.

As a next step, we could give the tests another mode (likely selected with an environment variable) where they also run a container for the divviup-ts client, so we can test container images after building them.