### PR TITLE
Fix `npm run docs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "rm -rf coverage && rm -rf .nyc_output && lerna run test:coverage",
     "lint": "lerna run lint",
     "ci": "npm run lint && npm run test:coverage",
-    "upgrade-interactive": "lerna exec -- npm-upgrade"
+    "upgrade-interactive": "lerna exec -- npm-upgrade",
+    "docs": "lerna run docs"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.8.3",


### PR DESCRIPTION
The `docs` workflow has been failing for about 7 months ([1]). We just need the top-level `package.json`'s `docs` command to dispatch to each sub-package's `docs` script.

[1]: https://github.com/divviup/divviup-ts/actions/workflows/docs.yml