### PR TITLE
Merge TypeScript docs across packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "npm-upgrade": "^3.1.0",
         "nx": "16.0.2",
         "parcel": "^2.8.3",
+        "typedoc-plugin-missing-exports": "^2.0.0",
         "typescript": "^5.0.3"
       }
     },
@@ -18761,6 +18762,15 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.0.0.tgz",
+      "integrity": "sha512-t0QlKCm27/8DaheJkLo/gInSNjzBXgSciGhoLpL6sLyXZibm7SuwJtHvg4qXI2IjJfFBgW9mJvvszpoxMyB0TA==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.24.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "lerna run lint",
     "ci": "npm run lint && npm run test:coverage",
     "upgrade-interactive": "lerna exec -- npm-upgrade",
-    "docs": "lerna run docs"
+    "docs": "typedoc"
   },
   "devDependencies": {
     "@parcel/packager-ts": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "npm-upgrade": "^3.1.0",
     "nx": "16.0.2",
     "parcel": "^2.8.3",
+    "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "^5.0.3"
   }
 }

--- a/packages/common/typedoc.json
+++ b/packages/common/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/dap/src/index.ts
+++ b/packages/dap/src/index.ts
@@ -1,1 +1,2 @@
 export { DAPClient, DAPClient as default } from "./client";
+export { DAPError } from "./errors";

--- a/packages/dap/typedoc.json
+++ b/packages/dap/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/field/typedoc.json
+++ b/packages/field/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/prg/typedoc.json
+++ b/packages/prg/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/prio3/typedoc.json
+++ b/packages/prio3/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/vdaf/typedoc.json
+++ b/packages/vdaf/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "preserveConstEnums": true,
     "esModuleInterop": true,
     "declaration": true,
+    "declarationMap": true,
     "plugins": [
       {
         "name": "typescript-eslint-language-service"

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,5 @@
+{
+  "exclude": ["**/*.spec.ts"],
+  "excludeInternal": true,
+  "excludePrivate": true
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,5 +8,6 @@
     "packages/prg",
     "packages/prio3",
     "packages/vdaf"
-  ]
+  ],
+  "plugin": "typedoc-plugin-missing-exports"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,12 @@
 {
-  "entryPointStrategy": "expand",
-  "exclude": ["**/*.spec.ts"],
-  "excludeInternal": true,
-  "excludePrivate": true
+  "extends": ["./typedoc.base.json"],
+  "entryPointStrategy": "packages",
+  "entryPoints": [
+    "packages/common",
+    "packages/dap",
+    "packages/field",
+    "packages/prg",
+    "packages/prio3",
+    "packages/vdaf"
+  ]
 }


### PR DESCRIPTION
This updates some configuration files to get typedoc merging documentation across packages. This uses the new "packages" entry point strategy from typedoc version 0.24.

`typedoc` is emitting some warnings, mostly related to item visibility, so I'll get those cleaned up before marking this ready for review.