### PR TITLE
Run build before generating docs in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         node-version: 18
     - run: npm ci
+    - run: npm run build
     - run: npm run docs
     - name: deploy
       uses: JamesIves/github-pages-deploy-action@v4.4.1


### PR DESCRIPTION
The docs workflow is still failing, this should fix it by building type declarations first.