### PR TITLE
Drop support for `draft-ietf-ppm-dap-03`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: release/dap-draft-03
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: release/dap-draft-03

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ The `main` branch is under continuous development and will usually be partway be
 | Git branch | Draft version | Conforms to specification? | Status |
 | ---------- | ------------- | -------------------------- | ------ |
 | `release/dap-draft-02` | [`draft-ietf-ppm-dap-02`][dap-02] | Yes | Unmaintained |
-| `release/dap-draft-03` | [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Supported |
-| `main` | `draft-ietf-ppm-dap-04` (forthcoming) | Partially | Supported |
+| `release/dap-draft-03` | [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Unmaintained as of May 22, 2023 |
+| `main` | [`draft-ietf-ppm-dap-04`][dap-04] | [Partially][dap-04-issue] | Supported |
 
 [dap-02]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/
 [dap-03]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/
+[dap-04]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/
+[dap-04-issue]: https://github.com/divviup/divviup-ts/issues/216
 
 ## Usage
 


### PR DESCRIPTION
Updates `README.md` and dependabot configuration to indicate that the `release/dap-draft-03` branch is no longer supported and that `main` is now working toward implementing `draft-ietf-ppm-dap-04`.