### PR TITLE
Stop relying on experimental-specifier-resolution

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,5 @@
 {
   "node-option": [
-    "experimental-specifier-resolution=node",
     "loader=ts-node/esm",
     "no-warnings"
   ]

--- a/packages/common/src/index.spec.ts
+++ b/packages/common/src/index.spec.ts
@@ -11,7 +11,7 @@ import {
   concat,
   arr,
   fill,
-} from "./index";
+} from "./index.js";
 
 describe("common", () => {
   describe("integerToOctetStringLE", () => {

--- a/packages/dap/src/aggregator.spec.ts
+++ b/packages/dap/src/aggregator.spec.ts
@@ -1,15 +1,15 @@
-import { Aggregator } from "./aggregator";
+import { Aggregator } from "./aggregator.js";
 import assert from "assert";
-import { Role } from "./constants";
-import { HpkeConfig, HpkeConfigList } from "./hpkeConfig";
+import { Role } from "./constants.js";
+import { HpkeConfig, HpkeConfigList } from "./hpkeConfig.js";
 import {
   InputShareAad,
   InputShareInfo,
   PlaintextInputShare,
   ReportMetadata,
-} from "./report";
-import { TaskId } from "./taskId";
-import { ReportId } from "./reportId";
+} from "./report.js";
+import { TaskId } from "./taskId.js";
+import { ReportId } from "./reportId.js";
 import { KdfId, AeadId } from "hpke-js";
 import { DhkemP256HkdfSha256 } from "@hpke/core";
 

--- a/packages/dap/src/aggregator.ts
+++ b/packages/dap/src/aggregator.ts
@@ -1,7 +1,11 @@
-import { Role } from "./constants";
-import { InputShareAad, InputShareInfo, PlaintextInputShare } from "./report";
-import { HpkeCiphertext } from "./ciphertext";
-import { HpkeConfigList } from "./hpkeConfig";
+import { Role } from "./constants.js";
+import {
+  InputShareAad,
+  InputShareInfo,
+  PlaintextInputShare,
+} from "./report.js";
+import { HpkeCiphertext } from "./ciphertext.js";
+import { HpkeConfigList } from "./hpkeConfig.js";
 
 export class Aggregator {
   public url: URL;

--- a/packages/dap/src/ciphertext.spec.ts
+++ b/packages/dap/src/ciphertext.spec.ts
@@ -1,4 +1,4 @@
-import { HpkeCiphertext } from "./ciphertext";
+import { HpkeCiphertext } from "./ciphertext.js";
 import assert from "assert";
 describe("DAP HpkeCiphertext", () => {
   it("cannot be built from a negative configId", () => {

--- a/packages/dap/src/ciphertext.ts
+++ b/packages/dap/src/ciphertext.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import { Encodable, encodeOpaque16, encodeOpaque32 } from "./encoding";
+import { Encodable, encodeOpaque16, encodeOpaque32 } from "./encoding.js";
 
 export class HpkeCiphertext implements Encodable {
   constructor(

--- a/packages/dap/src/client.spec.ts
+++ b/packages/dap/src/client.spec.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
-import { DAPClient, KnownVdafSpec, VdafMeasurement } from "./client";
-import { HpkeConfig, HpkeConfigList } from "./hpkeConfig";
-import { TaskId } from "./taskId";
-import { DAPError } from "./errors";
+import { DAPClient, KnownVdafSpec, VdafMeasurement } from "./client.js";
+import { HpkeConfig, HpkeConfigList } from "./hpkeConfig.js";
+import { TaskId } from "./taskId.js";
+import { DAPError } from "./errors.js";
 import { zip } from "@divviup/common";
-import { encodeOpaque32 } from "./encoding";
+import { encodeOpaque32 } from "./encoding.js";
 import { Prio3Count, Prio3Histogram, Prio3Sum } from "@divviup/prio3";
 import { inspect } from "node:util";
 import { KdfId, AeadId, CipherSuite } from "hpke-js";

--- a/packages/dap/src/client.ts
+++ b/packages/dap/src/client.ts
@@ -1,22 +1,22 @@
 import { Buffer } from "buffer";
-import { TaskId } from "./taskId";
-import { ReportId } from "./reportId";
+import { TaskId } from "./taskId.js";
+import { ReportId } from "./reportId.js";
 import {
   Report,
   ReportMetadata,
   InputShareAad,
   PlaintextInputShare,
-} from "./report";
-import { HpkeConfigList } from "./hpkeConfig";
+} from "./report.js";
+import { HpkeConfigList } from "./hpkeConfig.js";
 import { ClientVdaf } from "@divviup/vdaf";
-import { Extension } from "./extension";
-import { DAPError } from "./errors";
-import { CONTENT_TYPES, DAP_VERSION } from "./constants";
-import { Aggregator } from "./aggregator";
+import { Extension } from "./extension.js";
+import { DAPError } from "./errors.js";
+import { CONTENT_TYPES, DAP_VERSION } from "./constants.js";
+import { Aggregator } from "./aggregator.js";
 import { Prio3Count, Prio3Histogram, Prio3Sum } from "@divviup/prio3";
 import { randomBytes } from "@divviup/common";
 
-export { TaskId } from "./taskId";
+export { TaskId } from "./taskId.js";
 
 export interface ReportOptions {
   timestamp?: Date;

--- a/packages/dap/src/encoding.spec.ts
+++ b/packages/dap/src/encoding.spec.ts
@@ -7,7 +7,7 @@ import {
   encodeOpaque16,
   Parser,
   ParseSource,
-} from "./encoding";
+} from "./encoding.js";
 
 class Uint16 implements Encodable {
   constructor(public n: number) {}

--- a/packages/dap/src/errors.spec.ts
+++ b/packages/dap/src/errors.spec.ts
@@ -1,4 +1,4 @@
-import { DAPError } from "./errors";
+import { DAPError } from "./errors.js";
 import assert from "assert";
 
 describe("DAPError", () => {

--- a/packages/dap/src/errors.ts
+++ b/packages/dap/src/errors.ts
@@ -1,4 +1,4 @@
-import { TaskId } from "./taskId";
+import { TaskId } from "./taskId.js";
 
 interface Problem {
   type: string;

--- a/packages/dap/src/extension.ts
+++ b/packages/dap/src/extension.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import { Encodable } from "./encoding";
+import { Encodable } from "./encoding.js";
 
 enum ExtensionType {
   TBD,

--- a/packages/dap/src/hpkeConfig.spec.ts
+++ b/packages/dap/src/hpkeConfig.spec.ts
@@ -1,4 +1,4 @@
-import { HpkeConfig, HpkeConfigList } from "./hpkeConfig";
+import { HpkeConfig, HpkeConfigList } from "./hpkeConfig.js";
 import assert from "assert";
 import { KemId, KdfId, AeadId } from "hpke-js";
 import { DhkemX25519HkdfSha256 } from "@hpke/dhkem-x25519";

--- a/packages/dap/src/hpkeConfig.ts
+++ b/packages/dap/src/hpkeConfig.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "buffer";
 import { CipherSuite, KemId, KdfId, AeadId } from "hpke-js";
-import { Parser, ParseSource, Encodable, encodeArray16 } from "./encoding";
-import { HpkeCiphertext } from "./ciphertext";
+import { Parser, ParseSource, Encodable, encodeArray16 } from "./encoding.js";
+import { HpkeCiphertext } from "./ciphertext.js";
 
 export class HpkeConfigList implements Encodable {
   #selectedConfig?: HpkeConfig;

--- a/packages/dap/src/index.ts
+++ b/packages/dap/src/index.ts
@@ -1,6 +1,6 @@
-export { DAPClient, DAPClient as default } from "./client";
-export { DAPError } from "./errors";
-export type { ReportOptions } from "./client";
-export { KnownVdafSpec, VdafMeasurement } from "./client";
-export { TaskId } from "./taskId";
-export { HpkeConfig } from "./hpkeConfig";
+export { DAPClient, DAPClient as default } from "./client.js";
+export { DAPError } from "./errors.js";
+export type { ReportOptions } from "./client.js";
+export { KnownVdafSpec, VdafMeasurement } from "./client.js";
+export { TaskId } from "./taskId.js";
+export { HpkeConfig } from "./hpkeConfig.js";

--- a/packages/dap/src/report.spec.ts
+++ b/packages/dap/src/report.spec.ts
@@ -4,12 +4,12 @@ import {
   PlaintextInputShare,
   Report,
   ReportMetadata,
-} from "./report";
-import { TaskId } from "./taskId";
-import { ReportId } from "./reportId";
-import { HpkeCiphertext } from "./ciphertext";
+} from "./report.js";
+import { TaskId } from "./taskId.js";
+import { ReportId } from "./reportId.js";
+import { HpkeCiphertext } from "./ciphertext.js";
 import assert from "assert";
-import { Role } from "./constants";
+import { Role } from "./constants.js";
 
 describe("DAP Report", () => {
   it("encodes as expected", () => {

--- a/packages/dap/src/report.ts
+++ b/packages/dap/src/report.ts
@@ -1,15 +1,15 @@
 import { Buffer } from "buffer";
-import { TaskId } from "./taskId";
+import { TaskId } from "./taskId.js";
 import {
   Encodable,
   encodeArray32,
   encodeArray16,
   encodeOpaque32,
-} from "./encoding";
-import { ReportId } from "./reportId";
-import { HpkeCiphertext } from "./ciphertext";
-import { DAP_VERSION, Role } from "./constants";
-import { Extension } from "./extension";
+} from "./encoding.js";
+import { ReportId } from "./reportId.js";
+import { HpkeCiphertext } from "./ciphertext.js";
+import { DAP_VERSION, Role } from "./constants.js";
+import { Extension } from "./extension.js";
 
 export class ReportMetadata implements Encodable {
   constructor(

--- a/packages/dap/src/reportId.spec.ts
+++ b/packages/dap/src/reportId.spec.ts
@@ -1,4 +1,4 @@
-import { ReportId } from "./reportId";
+import { ReportId } from "./reportId.js";
 import assert from "assert";
 
 describe("DAP ReportID", () => {

--- a/packages/dap/src/reportId.ts
+++ b/packages/dap/src/reportId.ts
@@ -1,4 +1,4 @@
-import { Encodable } from "./encoding";
+import { Encodable } from "./encoding.js";
 import { randomBytes } from "@divviup/common";
 import { Buffer } from "buffer";
 

--- a/packages/dap/src/taskId.spec.ts
+++ b/packages/dap/src/taskId.spec.ts
@@ -1,4 +1,4 @@
-import { TaskId } from "./taskId";
+import { TaskId } from "./taskId.js";
 import assert from "assert";
 
 describe("DAP TaskId", () => {

--- a/packages/dap/src/taskId.ts
+++ b/packages/dap/src/taskId.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "buffer";
 import { randomBytes } from "@divviup/common";
-import { Encodable } from "./encoding";
+import { Encodable } from "./encoding.js";
 
 export class TaskId implements Encodable {
   buffer: Buffer;

--- a/packages/field/src/PrimeField.spec.ts
+++ b/packages/field/src/PrimeField.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { expect } from "chai";
-import { PrimeField } from "./PrimeField";
-import { Vector } from "./Vector";
+import { PrimeField } from "./PrimeField.js";
+import { Vector } from "./Vector.js";
 
 let F: PrimeField;
 

--- a/packages/field/src/PrimeField.ts
+++ b/packages/field/src/PrimeField.ts
@@ -1,6 +1,6 @@
 /// source: https://github.com/GuildOfWeavers/galois
 import { webcrypto } from "one-webcrypto";
-import { Vector } from "./Vector";
+import { Vector } from "./Vector.js";
 import { octetStringToIntegerBE } from "@divviup/common";
 
 // IMPORTS

--- a/packages/field/src/index.spec.ts
+++ b/packages/field/src/index.spec.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { Field, Field64, Field96, Field128 } from ".";
+import { Field, Field64, Field96, Field128 } from "./index.js";
 import { arr } from "@divviup/common";
 
 function testField(field: Field, name: string) {

--- a/packages/field/src/index.ts
+++ b/packages/field/src/index.ts
@@ -1,5 +1,5 @@
-import { PrimeField } from "./PrimeField";
-export { Vector } from "./Vector";
+import { PrimeField } from "./PrimeField.js";
+export { Vector } from "./Vector.js";
 import {
   integerToOctetStringLE,
   octetStringToIntegerLE,

--- a/packages/interop-test-client/package.json
+++ b/packages/interop-test-client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit -p ./tsconfig.json",
-    "start": "node --no-warnings --experimental-specifier-resolution=node --experimental-loader=ts-node/esm src/index.ts",
+    "start": "node --no-warnings --experimental-loader=ts-node/esm src/index.ts",
     "test": "mocha \"src/**/*.spec.ts\"",
     "lint": "eslint src --ext .ts && prettier -c src --ignore-path ../../.prettierignore",
     "format": "prettier -w src",

--- a/packages/interop-test-client/src/index.spec.ts
+++ b/packages/interop-test-client/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { app } from ".";
+import { app } from "./index.js";
 import { arr, randomBytes } from "@divviup/common";
 import { AddressInfo } from "node:net";
 import { spawnSync, SpawnSyncReturns } from "node:child_process";

--- a/packages/prg/src/index.spec.ts
+++ b/packages/prg/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { PrgSha3 } from ".";
+import { PrgSha3 } from "./index.js";
 import { Field128, Field64 } from "@divviup/field";
 import PrgSha3TestVector from "./testVectors/PrgSha3.json" assert { type: "json" };
 

--- a/packages/prg/src/index.ts
+++ b/packages/prg/src/index.ts
@@ -1,3 +1,3 @@
-export { Prg } from "./prg";
-export type { PrgConstructor } from "./prg";
-export { PrgSha3 } from "./sha3";
+export { Prg } from "./prg.js";
+export type { PrgConstructor } from "./prg.js";
+export { PrgSha3 } from "./sha3.js";

--- a/packages/prg/src/sha3.ts
+++ b/packages/prg/src/sha3.ts
@@ -1,5 +1,5 @@
 import jsSHA from "jssha";
-import { PrgConstructor, Prg } from "./prg";
+import { PrgConstructor, Prg } from "./prg.js";
 
 export const PrgSha3: PrgConstructor = class PrgSha3 extends Prg {
   static seedSize = 16;

--- a/packages/prio3/src/circuit.ts
+++ b/packages/prio3/src/circuit.ts
@@ -1,5 +1,5 @@
 import { Field } from "@divviup/field";
-import { Gadget } from "./gadget";
+import { Gadget } from "./gadget.js";
 import { nextPowerOf2 } from "@divviup/common";
 
 export interface GenericCircuit {

--- a/packages/prio3/src/circuits/count.ts
+++ b/packages/prio3/src/circuits/count.ts
@@ -1,6 +1,6 @@
-import { Circuit } from "../circuit";
+import { Circuit } from "../circuit.js";
 import { Field64 } from "@divviup/field";
-import { Mul } from "../gadgets/mul";
+import { Mul } from "../gadgets/mul.js";
 
 export class Count extends Circuit<boolean, number> {
   gadgets = [new Mul()];

--- a/packages/prio3/src/circuits/histogram.ts
+++ b/packages/prio3/src/circuits/histogram.ts
@@ -1,6 +1,6 @@
-import { Circuit } from "../circuit";
+import { Circuit } from "../circuit.js";
 import { Field128 } from "@divviup/field";
-import { PolyEval } from "../gadgets/polyEval";
+import { PolyEval } from "../gadgets/polyEval.js";
 
 export class Histogram extends Circuit<number, number[]> {
   gadgets = [new PolyEval([0n, -1n, 1n])];

--- a/packages/prio3/src/circuits/proof.ts
+++ b/packages/prio3/src/circuits/proof.ts
@@ -1,6 +1,6 @@
-import { Circuit } from "../circuit";
+import { Circuit } from "../circuit.js";
 import { Field } from "@divviup/field";
-import { Proof as ProofGadget } from "../gadgets/proof";
+import { Proof as ProofGadget } from "../gadgets/proof.js";
 
 export class Proof<M, AR> extends Circuit<M, AR> {
   gadgets: ProofGadget[];

--- a/packages/prio3/src/circuits/query.ts
+++ b/packages/prio3/src/circuits/query.ts
@@ -1,7 +1,7 @@
-import { Circuit } from "../circuit";
+import { Circuit } from "../circuit.js";
 import { Field } from "@divviup/field";
 import { nextPowerOf2 } from "@divviup/common";
-import { Query as QueryGadget } from "../gadgets/query";
+import { Query as QueryGadget } from "../gadgets/query.js";
 
 export class Query<M, AR> extends Circuit<M, AR> {
   gadgets: QueryGadget[];

--- a/packages/prio3/src/circuits/sum.ts
+++ b/packages/prio3/src/circuits/sum.ts
@@ -1,6 +1,6 @@
-import { Circuit } from "../circuit";
+import { Circuit } from "../circuit.js";
 import { Field128 } from "@divviup/field";
-import { PolyEval } from "../gadgets/polyEval";
+import { PolyEval } from "../gadgets/polyEval.js";
 import { arr } from "@divviup/common";
 
 export class Sum extends Circuit<number | bigint, bigint> {

--- a/packages/prio3/src/flp.spec.ts
+++ b/packages/prio3/src/flp.spec.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { Field, Field128 } from "@divviup/field";
-import { Flp } from "./flp";
+import { Flp } from "./flp.js";
 
 export function runFlp<M, AR>(
   flp: Flp<M, AR>,

--- a/packages/prio3/src/gadgets/mul.ts
+++ b/packages/prio3/src/gadgets/mul.ts
@@ -1,5 +1,5 @@
 import { Field } from "@divviup/field";
-import { Gadget } from "../gadget";
+import { Gadget } from "../gadget.js";
 
 export class Mul extends Gadget {
   arity = 2;

--- a/packages/prio3/src/gadgets/polyEval.ts
+++ b/packages/prio3/src/gadgets/polyEval.ts
@@ -1,6 +1,6 @@
 import { fill } from "@divviup/common";
 import { Field } from "@divviup/field";
-import { Gadget } from "../gadget";
+import { Gadget } from "../gadget.js";
 
 function stripPolynomial(polynomial: bigint[]): bigint[] {
   let index = polynomial.length - 1;

--- a/packages/prio3/src/gadgets/proof.ts
+++ b/packages/prio3/src/gadgets/proof.ts
@@ -1,6 +1,6 @@
 import { Field } from "@divviup/field";
 import { arr, fill, nextPowerOf2 } from "@divviup/common";
-import { Gadget } from "../gadget";
+import { Gadget } from "../gadget.js";
 
 export class Proof extends Gadget {
   gadget: Gadget;

--- a/packages/prio3/src/gadgets/query.ts
+++ b/packages/prio3/src/gadgets/query.ts
@@ -1,6 +1,6 @@
 import { Field } from "@divviup/field";
 import { nextPowerOf2, arr, fill } from "@divviup/common";
-import { Gadget } from "../gadget";
+import { Gadget } from "../gadget.js";
 
 export class Query extends Gadget {
   wire: bigint[][];

--- a/packages/prio3/src/genericFlp.spec.ts
+++ b/packages/prio3/src/genericFlp.spec.ts
@@ -1,15 +1,15 @@
-import { Gadget } from "./gadget";
+import { Gadget } from "./gadget.js";
 import { Field, Field128, Field64 } from "@divviup/field";
-import { Count } from "./circuits/count";
-import { Sum } from "./circuits/sum";
-import { Histogram } from "./circuits/histogram";
-import { FlpGeneric } from "./genericFlp";
-import { runFlp } from "./flp.spec";
-import { Circuit, GenericCircuit } from "./circuit";
+import { Count } from "./circuits/count.js";
+import { Sum } from "./circuits/sum.js";
+import { Histogram } from "./circuits/histogram.js";
+import { FlpGeneric } from "./genericFlp.js";
+import { runFlp } from "./flp.spec.js";
+import { Circuit, GenericCircuit } from "./circuit.js";
 import { arr, nextPowerOf2 } from "@divviup/common";
 import assert from "assert";
-import { PolyEval } from "./gadgets/polyEval";
-import { Mul } from "./gadgets/mul";
+import { PolyEval } from "./gadgets/polyEval.js";
+import { Mul } from "./gadgets/mul.js";
 
 function testGadget(gadget: Gadget, field: Field, testLength: number) {
   const evalAt = field.randomElement();

--- a/packages/prio3/src/genericFlp.ts
+++ b/packages/prio3/src/genericFlp.ts
@@ -1,9 +1,9 @@
 import { arr } from "@divviup/common";
-import { Flp } from "./flp";
+import { Flp } from "./flp.js";
 import { Field } from "@divviup/field";
-import { Circuit } from "./circuit";
-import { Query } from "./circuits/query";
-import { Proof } from "./circuits/proof";
+import { Circuit } from "./circuit.js";
+import { Query } from "./circuits/query.js";
+import { Proof } from "./circuits/proof.js";
 
 export class FlpGeneric<M, AR> implements Flp<M, AR> {
   constructor(public circuit: Circuit<M, AR>) {}

--- a/packages/prio3/src/index.ts
+++ b/packages/prio3/src/index.ts
@@ -1,2 +1,2 @@
-export { Prio3 } from "./prio3";
-export { Prio3Count, Prio3Histogram, Prio3Sum } from "./instantiations";
+export { Prio3 } from "./prio3.js";
+export { Prio3Count, Prio3Histogram, Prio3Sum } from "./instantiations.js";

--- a/packages/prio3/src/instantiations.ts
+++ b/packages/prio3/src/instantiations.ts
@@ -1,9 +1,9 @@
 import { PrgSha3 } from "@divviup/prg";
-import { Prio3 } from ".";
-import { FlpGeneric } from "./genericFlp";
-import { Count } from "./circuits/count";
-import { Histogram } from "./circuits/histogram";
-import { Sum } from "./circuits/sum";
+import { Prio3 } from "./index.js";
+import { FlpGeneric } from "./genericFlp.js";
+import { Count } from "./circuits/count.js";
+import { Histogram } from "./circuits/histogram.js";
+import { Sum } from "./circuits/sum.js";
 
 export class Prio3Count extends Prio3<boolean, number> {
   constructor({ shares }: { shares: number }) {

--- a/packages/prio3/src/prio3.spec.ts
+++ b/packages/prio3/src/prio3.spec.ts
@@ -1,7 +1,7 @@
-import { Prio3 } from ".";
+import { Prio3 } from "./index.js";
 import assert from "assert";
-import { Prio3Count, Prio3Histogram, Prio3Sum } from "./instantiations";
-import { TestFlp128 } from "./flp.spec";
+import { Prio3Count, Prio3Histogram, Prio3Sum } from "./instantiations.js";
+import { TestFlp128 } from "./flp.spec.js";
 import { PrgSha3 } from "@divviup/prg";
 import { TestVector } from "@divviup/vdaf";
 import { arr } from "@divviup/common";

--- a/packages/prio3/src/prio3.ts
+++ b/packages/prio3/src/prio3.ts
@@ -2,7 +2,7 @@ import { Shares, Vdaf } from "@divviup/vdaf";
 import { PrgConstructor } from "@divviup/prg";
 import { fill, arr, concat } from "@divviup/common";
 import { Field } from "@divviup/field";
-import { Flp } from "./flp";
+import { Flp } from "./flp.js";
 import { Buffer } from "buffer";
 
 type PrepareState = {

--- a/packages/vdaf/src/index.spec.ts
+++ b/packages/vdaf/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { Field128 } from "@divviup/field";
-import { Shares, Vdaf } from ".";
+import { Shares, Vdaf } from "./index.js";
 import { PrgSha3 } from "@divviup/prg";
 import assert from "assert";
 


### PR DESCRIPTION
This fixes #374 by adding `.js` extensions to all intra-package ESM import statements. I also removed the `--experimental-specifier-resolution=node` flag from mocha configuration and one other node command. I tested with the same external plain Node.js project I initially found this issue with, and it can import the packages from tarballs with no further intervention. Based on [documentation](https://www.typescriptlang.org/docs/handbook/esm-node.html), this appears to be the preferred way to handle ESM imports in TypeScript. (The project has rejected proposals to have `tsc` rewrite import statements, FWIW) I also confirmed that VS Code's go to definition feature correctly navigates to source `.ts` files when used on these updated import statements.