### PR TITLE
Add Dependabot group for hpke-js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      hpke-js:
+        patterns:
+          - "hpke-js"
+          - "@hpke/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This adds a Dependabot group for the packages we use from the hpke-js monorepo.