### PR TITLE
Add GitHub Actions workflow to publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Clean install
         run: npm ci
+      - name: Test
+        run: npm run test
       - name: Build
         run: npm build
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Clean install
+        run: npm ci
+      - name: Build
+        run: npm build
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |-
+          npm publish \
+            -w packages/common \
+            -w packages/field \
+            -w packages/prg \
+            -w packages/vdaf \
+            -w packages/prio3 \
+            -w packages/dap


### PR DESCRIPTION
This adds a workflow to run `npm publish` on all our (non-private) packages.