### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Clean install
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Test
         run: npm run test
-      - name: Build
-        run: npm build
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This fixes two problems with the publish workflow. First, `npm build` does not work, as we need to use the `npm run` command instead to hit our package script. Secondly, we need to build before running tests, because intra-workspace package imports need the `dist` subdirectories to exist.