### PR TITLE
Exclude tests and test vectors from packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ coverage/
 .github
 typedoc.base.json
 **/typedoc.json
+**/*.spec.*
+**/testVectors/


### PR DESCRIPTION
This adds two patterns to `.npmignore` to exclude test files and test vectors. I figure we may as well leave these out, since they won't be used. I confirmed that a separate package importing the resulting tarballs runs fine without these files.