### PR TITLE
Prepare to branch for DAP-04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Manage dependencies on the `release/dap-draft-04` branch
+  - package-ecosystem: "npm"
+    target-branch: "release/dap-draft-04"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      hpke-js:
+        patterns:
+          - "hpke-js"
+          - "@hpke/*"
+  - package-ecosystem: "github-actions"
+    target-branch: "release/dap-draft-04"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ The `main` branch is under continuous development and will usually be partway be
 | ---------- | ------------- | -------------------------- | ------ |
 | `release/dap-draft-02` | [`draft-ietf-ppm-dap-02`][dap-02] | Yes | Unmaintained |
 | `release/dap-draft-03` | [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Unmaintained as of May 22, 2023 |
-| `main` | [`draft-ietf-ppm-dap-04`][dap-04] | [Partially][dap-04-issue] | Supported |
+| `release/dap-draft-04` | [`draft-ietf-ppm-dap-04`][dap-04] | Yes | Supported |
+| `main` | [`draft-ietf-ppm-dap-07`][dap-07] | [Partially][dap-07-issue] | Supported |
 
 [dap-02]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/
 [dap-03]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/
 [dap-04]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/
-[dap-04-issue]: https://github.com/divviup/divviup-ts/issues/216
+[dap-07]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/07/
+[dap-07-issue]: https://github.com/divviup/divviup-ts/issues/359
 
 ## Usage
 


### PR DESCRIPTION
Update README to indicate that DAP-04 support is complete and that DAP-07 support is being worked on.

Update dependabot config to manage `release/dap-draft-04`.