### PR TITLE
Create new packages with public access enabled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |-
           npm publish \
+            --access public \
             -w packages/common \
             -w packages/field \
             -w packages/prg \


### PR DESCRIPTION
Scoped package names by default imply restricted package access, which is a paid feature. This will only be needed the first time any package is published.