### PR TITLE
bump versions for dap-07 and vdaf-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7303,19 +7303,19 @@
       }
     },
     "packages/common": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "one-webcrypto": "^1.0.3"
       }
     },
     "packages/dap": {
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "^0.2.0",
-        "@divviup/prio3": "^0.2.0",
-        "@divviup/vdaf": "^0.2.0",
+        "@divviup/common": "^0.2.1",
+        "@divviup/prio3": "^0.7.0",
+        "@divviup/vdaf": "^0.7.0",
         "hpke-js": "^1.2.4"
       },
       "devDependencies": {
@@ -7325,7 +7325,7 @@
       }
     },
     "packages/field": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@divviup/common": "^0.2.0",
@@ -7335,7 +7335,7 @@
     "packages/interop-test-client": {
       "version": "0.0.0",
       "dependencies": {
-        "@divviup/dap": "^0.2.0",
+        "@divviup/dap": "*",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -7344,30 +7344,30 @@
       }
     },
     "packages/prio3": {
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "^0.2.0",
-        "@divviup/field": "^0.2.0",
-        "@divviup/vdaf": "^0.2.0",
-        "@divviup/xof": "^0.2.0",
+        "@divviup/common": "^0.2.1",
+        "@divviup/field": "^0.2.1",
+        "@divviup/vdaf": "^0.7.0",
+        "@divviup/xof": "^0.1.0",
         "buffer": "^6.0.3"
       }
     },
     "packages/vdaf": {
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "^0.2.0",
+        "@divviup/common": "^0.2.1",
         "buffer": "^6.0.3"
       }
     },
     "packages/xof": {
-      "version": "0.2.0",
+      "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@divviup/common": "^0.2.0",
-        "@divviup/field": "^0.2.0",
+        "@divviup/common": "^0.2.1",
+        "@divviup/field": "^0.2.1",
         "jssha": "^3.3.1"
       }
     }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/common",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/dap/package.json
+++ b/packages/dap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/dap",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,9 +19,9 @@
     "test:coverage": "c8 npm test"
   },
   "dependencies": {
-    "@divviup/common": "^0.2.0",
-    "@divviup/prio3": "^0.2.0",
-    "@divviup/vdaf": "^0.2.0",
+    "@divviup/common": "^0.2.1",
+    "@divviup/prio3": "^0.7.0",
+    "@divviup/vdaf": "^0.7.0",
     "hpke-js": "^1.2.4"
   },
   "devDependencies": {

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/field",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/interop-test-client/package.json
+++ b/packages/interop-test-client/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "c8 npm test"
   },
   "dependencies": {
-    "@divviup/dap": "^0.2.0",
+    "@divviup/dap": "*",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/packages/prio3/package.json
+++ b/packages/prio3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/prio3",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,10 +19,10 @@
   "type": "module",
   "license": "MPL-2.0",
   "dependencies": {
-    "@divviup/common": "^0.2.0",
-    "@divviup/field": "^0.2.0",
-    "@divviup/xof": "^0.2.0",
-    "@divviup/vdaf": "^0.2.0",
+    "@divviup/common": "^0.2.1",
+    "@divviup/field": "^0.2.1",
+    "@divviup/xof": "^0.1.0",
+    "@divviup/vdaf": "^0.7.0",
     "buffer": "^6.0.3"
   }
 }

--- a/packages/vdaf/package.json
+++ b/packages/vdaf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/vdaf",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,7 @@
     "format": "prettier -w src"
   },
   "dependencies": {
-    "@divviup/common": "^0.2.0",
+    "@divviup/common": "^0.2.1",
     "buffer": "^6.0.3"
   }
 }

--- a/packages/xof/package.json
+++ b/packages/xof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/xof",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,8 +19,8 @@
     "test:coverage": "c8 npm test"
   },
   "dependencies": {
-    "@divviup/common": "^0.2.0",
-    "@divviup/field": "^0.2.0",
+    "@divviup/common": "^0.2.1",
+    "@divviup/field": "^0.2.1",
     "jssha": "^3.3.1"
   }
 }


### PR DESCRIPTION
For review:

The version strategy this PR uses is as follows
* patch-bump packages that have only non-breaking changes (`@divviup/field`, `@divviup/common`)
* update minor versions of rfc-draft-tracking packages to their relevant draft versions, which happen to all be 07 (`@divviup/dap`, `@divviup/vdaf`, `@divviup/prio3`)
* start `@divviup/xof` out at 0.1, as it has no previous releases