### PR TITLE
copy readme into packages before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
+      - name: Copy README.md into packages if none exists
+        run: for DIR in packages/*; do cp -n ./README.md $DIR; done
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
apparently npm doesn't like symlinks (https://github.com/npm/cli/issues/ 6746) so we copy them on publish. eventually we should write full per-package READMEs but this is better than nothing