### PR TITLE
Update ts-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "mocha": "^10.2.0",
         "npm-upgrade": "^3.1.0",
         "prettier": "^3.1.0",
-        "ts-node": "^10.9.1",
+        "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typedoc": "^0.25.4",
         "typedoc-plugin-missing-exports": "^2.1.0",
@@ -6846,9 +6846,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mocha": "^10.2.0",
     "npm-upgrade": "^3.1.0",
     "prettier": "^3.1.0",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typedoc": "^0.25.4",
     "typedoc-plugin-missing-exports": "^2.1.0",


### PR DESCRIPTION
The release/dap-draft-04 branch got broken a while back by merging an update to typescript@5.3. (because required checks were missing from the branch protection rule at the time) This fixes it by updating to a compatible version of ts-node.