### PR TITLE
Interop test container: fix handling of "time"

### DIFF
--- a/packages/dap/src/task.spec.ts
+++ b/packages/dap/src/task.spec.ts
@@ -355,11 +355,11 @@ describe("Task", () => {
       const task = await withHpkeConfigs(new Task(buildParams()));
       const fetch = mockFetch({});
       task.fetch = fetch;
-      const timestamp = new Date(0);
+      const timestamp = new Date("2000-01-01T00:00:00");
       const report = await task.generateReport(1, {
         timestamp,
       });
-      assert.equal(report.metadata.time, timestamp.getTime());
+      assert.equal(report.metadata.time, timestamp.getTime() / 1000);
     });
 
     it("fails if the measurement is not valid", async () => {

--- a/packages/interop-test-client/src/index.ts
+++ b/packages/interop-test-client/src/index.ts
@@ -253,7 +253,7 @@ async function uploadHandler(req: Request, res: Response): Promise<void> {
 
   const options: ReportOptions = {};
   if (body.time !== undefined) {
-    options.timestamp = new Date(body.time);
+    options.timestamp = new Date(body.time * 1000);
   }
 
   try {


### PR DESCRIPTION
I was trying to specify `time` when using the upload interop test API endpoint, and it didn't work. The issue is that we are missing a conversion from seconds to milliseconds, which `new Date(value)` expects. I also improved a related unit test that made a similar mistake, but got away with it since it was using the epoch time itself.