### PR TITLE
Add Dependabot group of typedoc and related plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - "hpke-js"
           - "@hpke/*"
+      typedoc:
+        patterns:
+          - "typedoc"
+          - "typedoc-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Currently, Dependabot is failing to update typedoc and typedoc-plugin-missing-exports. The former has a PR that is failing due to unsatisfied peerDependencies, and the latter is stuck with `update_not_possible`. This adds a Dependabot group covering the two, which should hopefully unstick things. If not, we'll need a manual dependency update PR.