### PR TITLE
Specify signature of toJSON method in tests

### DIFF
--- a/packages/field/src/PrimeField.spec.ts
+++ b/packages/field/src/PrimeField.spec.ts
@@ -5,8 +5,7 @@ import { Vector } from "./Vector.js";
 let F: PrimeField;
 
 Object.assign(BigInt.prototype, {
-  toJSON() {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  toJSON(this: bigint) {
     return String(this) + "n";
   },
 });


### PR DESCRIPTION
Providing the type of the 'this' object addresses a no-base-to-string lint that was previously ignored.