### PR TITLE
Add ESM support to dap via package.json exports

### DIFF
--- a/packages/dap/package.json
+++ b/packages/dap/package.json
@@ -31,5 +31,11 @@
     "@hpke/core": "^1.7.1",
     "@hpke/dhkem-x25519": "^1.5.0",
     "esbuild": "^0.24.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    },
+    "./browser": "./dist/browser.js"
   }
 }


### PR DESCRIPTION
The `dap` package lacks ES module support. This change configures explicit import paths for ESM users (preferred by many bundlers like Vite) using the package.json `exports`  field. 
