### PR TITLE
Bump version of @divviup/dap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,7 +4545,7 @@
     },
     "packages/dap": {
       "name": "@divviup/dap",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@divviup/common": "^0.2.2",

--- a/packages/dap/package.json
+++ b/packages/dap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divviup/dap",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "browser": "dist/browser.js",
   "main": "dist/index.js",


### PR DESCRIPTION
This bumps the version of the @divviup/dap package, in preparation for a release, to pick up the new `exports` package metadata from #1034.