### PR TITLE
Update module and moduleResolution to nodenext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -972,6 +972,11 @@
       "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
       "dev": true
     },
+    "node_modules/@storacha/one-webcrypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@storacha/one-webcrypto/-/one-webcrypto-1.0.1.tgz",
+      "integrity": "sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ=="
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3470,11 +3475,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/one-webcrypto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
-      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q=="
-    },
     "node_modules/oniguruma-to-js": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.3.3.tgz",
@@ -4556,7 +4556,7 @@
       "version": "0.2.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "one-webcrypto": "^1.0.3"
+        "@storacha/one-webcrypto": "^1.0.1"
       }
     },
     "packages/dap": {
@@ -4582,7 +4582,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@divviup/common": "^0.2.2",
-        "one-webcrypto": "^1.0.3"
+        "@storacha/one-webcrypto": "^1.0.1"
       }
     },
     "packages/interop-test-client": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,6 @@
     "check": "tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
-    "one-webcrypto": "^1.0.3"
+    "@storacha/one-webcrypto": "^1.0.1"
   }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from "one-webcrypto";
+import { webcrypto } from "@storacha/one-webcrypto";
 
 /** @internal */
 export function integerToOctetStringBE(i: bigint, len: number): Uint8Array {

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "@divviup/common": "^0.2.2",
-    "one-webcrypto": "^1.0.3"
+    "@storacha/one-webcrypto": "^1.0.1"
   }
 }

--- a/packages/field/src/PrimeField.ts
+++ b/packages/field/src/PrimeField.ts
@@ -1,5 +1,5 @@
 /// source: https://github.com/GuildOfWeavers/galois
-import { webcrypto } from "one-webcrypto";
+import { webcrypto } from "@storacha/one-webcrypto";
 import { Vector } from "./Vector.js";
 import { octetStringToIntegerBE } from "@divviup/common";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,15 @@
     "sourceMap": true,
     "target": "ES2022",
     "lib": ["dom", "es2020"],
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "strict": true,
     "verbatimModuleSyntax": true,
     "preserveConstEnums": true,
     "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,
+    "moduleDetection": "force",
     "plugins": [
       {
         "name": "typescript-eslint-language-service"


### PR DESCRIPTION
The combination of `esnext + node` for TypeScript's module settings is not the recommended approach for modern Node.js projects: see [why-we-need-nodenext-typescript-compiler-option-when-we-have-esnext](https://stackoverflow.com/questions/71463698/why-we-need-nodenext-typescript-compiler-option-when-we-have-esnext) and [typescript reference](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext).

This PR implements two main changes:

1. Updates TypeScript configuration to use `nodenext + nodenext` for both `module` and `moduleResolution`
2. Replaces the outdated `one-webcrypto` dependency (last updated 3+ years ago) with `@storacha/one-webcrypto`, a maintained fork that supports modern module resolution patterns.